### PR TITLE
Add required Header for severity and additional headers option

### DIFF
--- a/alerting/relkon/README.md
+++ b/alerting/relkon/README.md
@@ -22,7 +22,9 @@ module "signalfx-integrations-alerting-relkon" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional\_headers | Any additional headers to send | map | `{}` | no |
 | enabled | Whether the Webhook integration is enabled | bool | `"true"` | no |
+| host\_severity | Host severity value as explained in our internal documentation | string | n/a | yes |
 | notification\_period | Notification period \(either 24x7 or 8x5\) | string | n/a | yes |
 | relkon\_token | Relkon API token | string | n/a | yes |
 | relkon\_url | Relkon API endpoint | string | n/a | yes |

--- a/alerting/relkon/README.md
+++ b/alerting/relkon/README.md
@@ -6,8 +6,10 @@
 module "signalfx-integrations-alerting-relkon" {
   source  = "github.com/claranet/terraform-signalfx-integrations.git//alerting/relkon"
 
+  relkon_url          = var.relkon_url
   relkon_token        = var.relkon_token
-  notification_period = var.notification_period 
+  notification_period = var.notification_period
+  host_severity       = 30 # Change it according to your needs and the relkon API documentation
 }
 
 ```

--- a/alerting/relkon/integrations-relkon.tf
+++ b/alerting/relkon/integrations-relkon.tf
@@ -11,5 +11,16 @@ resource "signalfx_webhook_integration" "relkon" {
     header_key   = "X-Relkon-Token"
     header_value = var.relkon_token
   }
+  headers {
+    header_key   = "X-Relkon-Host-Severity"
+    header_value = var.host_severity
+  }
+  dynamic "headers" {
+    for_each = var.additional_headers
+    content {
+      header_key   = headers.key
+      header_value = headers.value
+    }
+  }
 }
 

--- a/alerting/relkon/variables.tf
+++ b/alerting/relkon/variables.tf
@@ -28,3 +28,14 @@ variable "notification_period" {
   description = "Notification period (either 24x7 or 8x5)"
   type        = string
 }
+
+variable "host_severity" {
+  description = "Host severity value as explained in our internal documentation"
+  type        = string
+}
+
+variable "additional_headers" {
+  description = "Any additional headers to send"
+  type        = map
+  default     = {}
+}


### PR DESCRIPTION
* Add required variable `host_severity` needed to change alerting behavior
* Add the possibility to send any header we might need but are optional.

Can be merged as soon as our internal API has been updated.