### PR TITLE
Fix using externally managed GCP service account with authoritative IAM project policies

### DIFF
--- a/cloud/gcp/README.md
+++ b/cloud/gcp/README.md
@@ -41,6 +41,17 @@ module "signalfx-integrations-cloud-gcp" {
 
 ## Requirements
 
+**WARNING:** When the `gcp_service_account_id` parameter is not provided, this module creates a service account and uses the `google_project_iam_member` resource which is not compatible with IAM permissions set externally and authoritatively managed with the `google_project_iam_policy` resource. If you happen to use the `google_project_iam_policy` resource on the provided GCP project,
+make sure to provide the `gcp_service_account_id` parameter and ensure the corresponding service account has the appropriate IAM permissions on the GCP project:
+ - monitoring.metricDescriptors.get
+ - monitoring.metricDescriptors.list
+ - monitoring.timeSeries.list
+ - resourcemanager.projects.get
+ - compute.instances.list
+ - compute.machineTypes.list
+ - spanner.instances.list
+ - storage.buckets.list
+
 You need to configure your GCP and SignalFx providers.
 Credentials could be set in your `terraform.tfvars`.
 

--- a/cloud/gcp/integrations-gcp.tf
+++ b/cloud/gcp/integrations-gcp.tf
@@ -11,4 +11,3 @@ resource "signalfx_gcp_integration" "gcp_claranet_integration" {
 
   depends_on = [google_project_iam_member.sfx_service_account_membership]
 }
-

--- a/cloud/gcp/outputs.tf
+++ b/cloud/gcp/outputs.tf
@@ -1,4 +1,4 @@
 output "gcp_service_account_id" {
   description = "The GCP service account id used by SignalFx"
-  value       = google_service_account.sfx_service_account.*.id
+  value       = local.id_to_use
 }

--- a/cloud/gcp/permissions.tf
+++ b/cloud/gcp/permissions.tf
@@ -1,4 +1,6 @@
 resource "google_project_iam_custom_role" "sfx_role" {
+  count = var.gcp_service_account_id == "" ? 1 : 0
+
   role_id     = "signalfx${var.suffix == "" ? "" : ".${substr(lower(replace(var.suffix, "-", "_")), 0, 64)}"}"
   title       = "SignalFx${var.suffix == "" ? "" : " - ${title(var.suffix)}"}"
   description = "SignalFx viewer role for monitoring${var.suffix == "" ? "" : " for ${lower(var.suffix)}"}"
@@ -15,8 +17,9 @@ resource "google_project_iam_custom_role" "sfx_role" {
 }
 
 resource "google_project_iam_member" "sfx_service_account_membership" {
+  count = var.gcp_service_account_id == "" ? 1 : 0
+
   project = var.gcp_project_id
-  role    = "projects/${var.gcp_project_id}/roles/${google_project_iam_custom_role.sfx_role.role_id}"
+  role    = "projects/${var.gcp_project_id}/roles/${google_project_iam_custom_role.sfx_role[0].role_id}"
   member  = "serviceAccount:${google_service_account.sfx_service_account[0].email}"
 }
-

--- a/cloud/gcp/service-accounts.tf
+++ b/cloud/gcp/service-accounts.tf
@@ -1,8 +1,3 @@
-data "google_service_account" "sfx_service_account" {
-  count      = var.gcp_service_account_id != "" ? 1 : 0
-  account_id = var.gcp_service_account_id
-}
-
 resource "google_service_account" "sfx_service_account" {
   count        = var.gcp_service_account_id == "" ? 1 : 0
   account_id   = "signalfx${var.suffix == "" ? "" : "-${substr(lower(var.suffix), 0, 30)}"}"
@@ -10,10 +5,9 @@ resource "google_service_account" "sfx_service_account" {
 }
 
 locals {
-  id_to_use = length(data.google_service_account.sfx_service_account) > 0 ? data.google_service_account.sfx_service_account[0].id : google_service_account.sfx_service_account[0].id
+  id_to_use = var.gcp_service_account_id == "" ? google_service_account.sfx_service_account[0].id : var.gcp_service_account_id
 }
 
 resource "google_service_account_key" "sak" {
   service_account_id = local.id_to_use
 }
-

--- a/cloud/gcp/variables.tf
+++ b/cloud/gcp/variables.tf
@@ -36,4 +36,3 @@ variable "gcp_project_id" {
   description = "GCP project id for use with the SignalFx GCP integration"
   type        = string
 }
-

--- a/cloud/gcp/versions.tf
+++ b/cloud/gcp/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = "~> 0.12"
   required_providers {
@@ -6,4 +5,3 @@ terraform {
     signalfx = "~> 4"
   }
 }
-


### PR DESCRIPTION
Without this, it is not possible to use a service account managed outside of the module.