### PR TITLE
Set all available Azure services names by default

### DIFF
--- a/cloud/azure/integrations-azure.tf
+++ b/cloud/azure/integrations-azure.tf
@@ -1,3 +1,6 @@
+data "signalfx_azure_services" "azure_services" {
+}
+
 resource "signalfx_azure_integration" "azure_integration" {
   name        = local.integration_name
   enabled     = var.enabled
@@ -8,7 +11,7 @@ resource "signalfx_azure_integration" "azure_integration" {
   secret_key = azuread_service_principal_password.signalfx_integration_sp_pwd.value
   app_id     = azuread_application.signalfx_integration.application_id
 
-  services = var.services
+  services = coalescelist(var.services, data.signalfx_azure_services.azure_services.services[*].name)
 
   tenant_id     = var.azure_tenant_id
   subscriptions = var.azure_subscription_ids

--- a/cloud/azure/variables.tf
+++ b/cloud/azure/variables.tf
@@ -23,25 +23,7 @@ variable "poll_rate" {
 variable "services" {
   description = "Azure service metrics to import. Empty list imports all services"
   type        = list
-
-  # 2020-05-11 - List from https://www.terraform.io/docs/providers/signalfx/r/azure_integration.html#service-names
-  default = [
-    "microsoft.sql/servers/elasticpools",
-    "microsoft.storage/storageaccounts",
-    "microsoft.storage/storageaccountsservices/tableservices",
-    "microsoft.storage/storageaccountsservices/blobservices",
-    "microsoft.storage/storageaccounts/queueservices",
-    "microsoft.storage/storageaccounts/fileservices",
-    "microsoft.compute/virtualmachinescalesets",
-    "microsoft.compute/virtualmachinescalesets/virtualmachines",
-    "microsoft.compute/virtualmachines",
-    "microsoft.devices/iothubs",
-    "microsoft.eventHub/namespaces",
-    "microsoft.batch/batchaccounts",
-    "microsoft.sql/servers/databases",
-    "microsoft.cache/redis",
-    "microsoft.logic/workflows"
-  ]
+  default     = []
 }
 
 variable "azure_tenant_id" {

--- a/cloud/azure/variables.tf
+++ b/cloud/azure/variables.tf
@@ -23,7 +23,25 @@ variable "poll_rate" {
 variable "services" {
   description = "Azure service metrics to import. Empty list imports all services"
   type        = list
-  default     = []
+
+  # 2020-05-11 - List from https://www.terraform.io/docs/providers/signalfx/r/azure_integration.html#service-names
+  default = [
+    "microsoft.sql/servers/elasticpools",
+    "microsoft.storage/storageaccounts",
+    "microsoft.storage/storageaccountsservices/tableservices",
+    "microsoft.storage/storageaccountsservices/blobservices",
+    "microsoft.storage/storageaccounts/queueservices",
+    "microsoft.storage/storageaccounts/fileservices",
+    "microsoft.compute/virtualmachinescalesets",
+    "microsoft.compute/virtualmachinescalesets/virtualmachines",
+    "microsoft.compute/virtualmachines",
+    "microsoft.devices/iothubs",
+    "microsoft.eventHub/namespaces",
+    "microsoft.batch/batchaccounts",
+    "microsoft.sql/servers/databases",
+    "microsoft.cache/redis",
+    "microsoft.logic/workflows"
+  ]
 }
 
 variable "azure_tenant_id" {

--- a/cloud/azure/versions.tf
+++ b/cloud/azure/versions.tf
@@ -4,6 +4,6 @@ terraform {
   required_providers {
     azurerm  = "~> 1.44"
     azuread  = "~> 0.8"
-    signalfx = ">= 4.20.0"
+    signalfx = ">= 4.20.1"
   }
 }

--- a/cloud/azure/versions.tf
+++ b/cloud/azure/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12"
   required_providers {
     azurerm  = "~> 1.44"
-    azuread  = "~> 0.7"
-    signalfx = "~> 4"
+    azuread  = "~> 0.8"
+    signalfx = ">= 4.20.0"
   }
 }


### PR DESCRIPTION
 breaking change added with SignalFX provider `v4.19.0`
https://github.com/terraform-providers/terraform-provider-signalfx/blob/master/CHANGELOG.md#4190-april-13-2020

 > resource/signalfx_azure_integration: The services property is now
 > required and must have at least one item in it. #188

Issue opened: https://github.com/terraform-providers/terraform-provider-signalfx/issues/202