### PR TITLE
set github default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @xp-1000 @shr3ps @bzspi @cvauvarin


### PR DESCRIPTION
https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners

seems possible to use team which would be better if it changes often but should be enough for now