### PR TITLE
Azure: uses token and update doc and requirements

### DIFF
--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -27,14 +27,38 @@ module "signalfx-integrations-cloud-azure" {
 }
 ```
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.26 |
+| azuread | >= 1.1 |
+| azurerm | >= 2 |
+| signalfx | >= 4.26.4 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| azuread | >= 0.8 |
+| azuread | >= 1.1 |
 | azurerm | >= 2 |
 | random | n/a |
-| signalfx | >= 4.20.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sfx-integration | ./sfx |  |
+
+## Resources
+
+| Name |
+|------|
+| [azuread_application](https://registry.terraform.io/providers/hashicorp/azuread/1.1/docs/resources/application) |
+| [azuread_service_principal](https://registry.terraform.io/providers/hashicorp/azuread/1.1/docs/resources/service_principal) |
+| [azuread_service_principal_password](https://registry.terraform.io/providers/hashicorp/azuread/1.1/docs/resources/service_principal_password) |
+| [azurerm_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/2/docs/resources/role_assignment) |
+| [random_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) |
 
 ## Inputs
 
@@ -92,11 +116,12 @@ variable "azure_tenant_id" {
 provider "azurerm" {
   subscription_id = var.azure_subscription_id
   tenant_id       = var.azure_tenant_id
+  features {}
+  #skip_provider_registration = true
 }
 
 provider "azuread" {
-  subscription_id = var.azure_subscription_id
-  tenant_id       = var.azure_tenant_id
+  tenant_id = var.azure_tenant_id
 }
 
 ```

--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -128,8 +128,7 @@ provider "azuread" {
 
 ## Notes
 
-* This module will create an organization token and use it for ingesting data from the created GCP integration.
+* This module will create an organization token and use it for ingesting data from the created Azure integration.
   This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
 * As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin.
 * You need to be an AAD Applications Administrator and Owner on all Azure Subscriptions to monitor.
-

--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -128,6 +128,8 @@ provider "azuread" {
 
 ## Notes
 
+* This module will create an organization token and use it for ingesting data from the created GCP integration.
+  This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
 * As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin.
 * You need to be an AAD Applications Administrator and Owner on all Azure Subscriptions to monitor.
 

--- a/cloud/azure/sfx/README.md
+++ b/cloud/azure/sfx/README.md
@@ -87,7 +87,7 @@ provider "signalfx" {
 
 ## Notes
 
-* This module will create an organization token and use it for ingesting data from the created GCP integration.
+* This module will create an organization token and use it for ingesting data from the created Azure integration.
   This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
 * As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin.
 * You need to have an Azure Service Principal created with `Reader` Role granted over the SignalFX scope (ie: all monitored Azure Subscriptions).

--- a/cloud/azure/sfx/README.md
+++ b/cloud/azure/sfx/README.md
@@ -16,11 +16,30 @@ module "signalfx-integrations-cloud-azure" {
 }
 ```
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.26 |
+| signalfx | >= 4.26.4 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | signalfx | >= 4.26.4 |
+
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [signalfx_azure_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/4.26.4/docs/resources/azure_integration) |
+| [signalfx_azure_services](https://registry.terraform.io/providers/splunk-terraform/signalfx/4.26.4/docs/data-sources/azure_services) |
+| [signalfx_org_token](https://registry.terraform.io/providers/splunk-terraform/signalfx/4.26.4/docs/resources/org_token) |
 
 ## Inputs
 
@@ -32,7 +51,7 @@ module "signalfx-integrations-cloud-azure" {
 | azure\_tenant\_id | Azure Tenant ID/Directory ID | `string` | n/a | yes |
 | enabled | Whether the Azure integration is enabled | `bool` | `true` | no |
 | poll\_rate | Azure poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
-| services | Azure service metrics to import. Empty list imports all services | `list` | `[]` | no |
+| services | Azure service metrics to import. Empty list imports all services | `list(any)` | `[]` | no |
 | suffix | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 
 ## Outputs
@@ -68,5 +87,7 @@ provider "signalfx" {
 
 ## Notes
 
+* This module will create an organization token and use it for ingesting data from the created GCP integration.
+  This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
 * As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin.
 * You need to have an Azure Service Principal created with `Reader` Role granted over the SignalFX scope (ie: all monitored Azure Subscriptions).

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -4,10 +4,10 @@ data "signalfx_azure_services" "azure_services" {
 resource "signalfx_azure_integration" "azure_integration" {
   name        = local.integration_name
   enabled     = var.enabled
+  named_token = signalfx_org_token.azure_integration.name
   environment = "azure"
 
   poll_rate = var.poll_rate
-
 
   app_id     = var.azure_sp_application_id
   secret_key = var.azure_sp_application_token
@@ -17,3 +17,24 @@ resource "signalfx_azure_integration" "azure_integration" {
   tenant_id     = var.azure_tenant_id
   subscriptions = var.azure_subscription_ids
 }
+
+# "Named token to use for ingest on the SignalFx Azure integration"
+resource "signalfx_org_token" "azure_integration" {
+  name        = local.integration_name
+  description = "Org token for ingesting data from ${local.integration_name} Azure integration"
+
+  # Where to send notifications about this token's limits. Please consult the Notification Format laid out in detectors
+  # notifications = ["Email,foo-alerts@bar.com"]
+
+  # host_or_usage_limits {
+  #   host_limit                              = 100
+  #   host_notification_threshold             = 90
+  #   container_limit                         = 200
+  #   container_notification_threshold        = 180
+  #   custom_metrics_limit                    = 1000
+  #   custom_metrics_notification_threshold   = 900
+  #   high_res_metrics_limit                  = 1000
+  #   high_res_metrics_notification_threshold = 900
+  # }
+}
+

--- a/cloud/azure/sp-azure.tf
+++ b/cloud/azure/sp-azure.tf
@@ -1,5 +1,5 @@
 resource "azuread_application" "signalfx_integration" {
-  name     = local.integration_name
+  display_name     = local.integration_name
   homepage = "https://www.signalfx.com/"
 
   available_to_other_tenants = false

--- a/cloud/azure/sp-azure.tf
+++ b/cloud/azure/sp-azure.tf
@@ -1,6 +1,6 @@
 resource "azuread_application" "signalfx_integration" {
-  display_name     = local.integration_name
-  homepage = "https://www.signalfx.com/"
+  display_name = local.integration_name
+  homepage     = "https://www.signalfx.com/"
 
   available_to_other_tenants = false
   oauth2_allow_implicit_flow = false

--- a/cloud/azure/versions.tf
+++ b/cloud/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">= 1"
+      version = ">= 1.1"
     }
   }
   required_version = ">= 0.12.26"


### PR DESCRIPTION
- udpate readme with terraform-docs and fix examples
- requirement for azuread provider to 1.1: https://github.com/hashicorp/terraform-provider-azuread/issues/314
- fix depreacted "name" for azuread_application
- add signalfx token