### PR TITLE
gcp_compute_metadata_whitelist: add default value matching terraform-…

### DIFF
--- a/cloud/gcp/README.md
+++ b/cloud/gcp/README.md
@@ -10,7 +10,6 @@ module "signalfx-integrations-cloud-gcp" {
 }
 
 ```
-
 ## Requirements
 
 | Name | Version |
@@ -47,7 +46,7 @@ No Modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | enabled | Whether the GCP integration is enabled | `bool` | `true` | no |
-| gcp\_compute\_metadata\_whitelist | List of GCP compute metadata to whitelist for use with the SignalFx GCP integration | `list(string)` | `null` | no |
+| gcp\_compute\_metadata\_whitelist | List of GCP compute metadata to whitelist for use with the SignalFx GCP integration | `list(string)` | <pre>[<br>  "sfx_env",<br>  "sfx_monitored"<br>]</pre> | no |
 | gcp\_project\_id | GCP project id for use with the SignalFx GCP integration | `string` | n/a | yes |
 | gcp\_service\_account\_id | GCP service account id for use with the SignalFx GCP integration | `string` | `""` | no |
 | host\_or\_usage\_limits | Specify Usage-based limits for this integration | `map(number)` | `null` | no |

--- a/cloud/gcp/locals.tf
+++ b/cloud/gcp/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  id_to_use = var.gcp_service_account_id == "" ? google_service_account.sfx_service_account[0].id : var.gcp_service_account_id
+  id_to_use        = var.gcp_service_account_id == "" ? google_service_account.sfx_service_account[0].id : var.gcp_service_account_id
   integration_name = "GCPIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
 }
 

--- a/cloud/gcp/variables.tf
+++ b/cloud/gcp/variables.tf
@@ -41,7 +41,7 @@ variable "services" {
 variable "gcp_compute_metadata_whitelist" {
   description = "List of GCP compute metadata to whitelist for use with the SignalFx GCP integration"
   type        = list(string)
-  default     = null
+  default     = ['sfx_env', 'sfx_monitored']
 }
 
 variable "gcp_project_id" {

--- a/cloud/gcp/variables.tf
+++ b/cloud/gcp/variables.tf
@@ -41,7 +41,7 @@ variable "services" {
 variable "gcp_compute_metadata_whitelist" {
   description = "List of GCP compute metadata to whitelist for use with the SignalFx GCP integration"
   type        = list(string)
-  default     = ['sfx_env', 'sfx_monitored']
+  default     = ["sfx_env", "sfx_monitored"]
 }
 
 variable "gcp_project_id" {


### PR DESCRIPTION
…signalfx-detectors gcp-compute-engine default filter

https://github.com/claranet/terraform-signalfx-detectors/blob/80f40ac2ec3af35e1357026d11ba4c24dccfb9d4/modules/integration_gcp-compute-engine/modules.tf#L4