### PR TITLE
add wait workaround to prevent aws permission denied on role

### DIFF
--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -113,7 +113,7 @@ provider "aws" {
   This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
 * As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin
 * You need to be an IAM admin on AWS account
-* The first apply could fail with error `is not authorized to perform: sts:AssumeRole on resource:` when AWS signalfx integration is configured before the policy attachment to IAM role from AWS side that it is actualy available
+* The apply will wait between the AWS policy attachment to role and the signalfx aws integration creation to prevent permission denied error
 * This module does not support `services` and `custom_cloudwatch_namespaces` because `namespace_sync_rule` and `custom_namespace_sync_rule` are respectively more powerful but in conflict
 
 ### Namespaces filtering

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -59,5 +59,10 @@ resource "signalfx_aws_integration" "aws_integration" {
     filter_source  = var.custom_namespace_sync_rule.filter_source
     namespace      = var.custom_namespace_sync_rule.namespace
   }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.sfx_policy_attach,
+    time_sleep.policy_availability
+  ]
 }
 

--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -8,3 +8,11 @@ resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {
   role       = aws_iam_role.sfx_role.name
   policy_arn = aws_iam_policy.sfx_policy.arn
 }
+
+# workaround to be sure the policy is really applied to the role before to try to create the integration
+resource "time_sleep" "policy_availability" {
+  depends_on = [aws_iam_role_policy_attachment.sfx_policy_attach]
+
+  create_duration = "15s"
+}
+


### PR DESCRIPTION
as described in the readme currently, the first apply often fail for aws integration.

this is because even if the policy attachment resource is created (aws api ok response), this policy does not immediately affect the underlying role.

so terraform tries to create the integration which fails with a permission denied error.

this pr add a workaround to wait 15 s after the policy attachment and before the integration creation.

another ways could be:
- improve signalfx provider to add back off retry on creation
- improve aws provider to "sleep" after policy attachment to return response only when right applied
- use a inline policy in the role resource in this module instead of a dedicated policy which require an attachment (cause the undesired delay)