### PR TITLE
feat(aws): Enable usage of Cloudwatch Metric Streams for ingesting metrics

### DIFF
--- a/cloud/aws-cloudwatch-metric-stream/README.md
+++ b/cloud/aws-cloudwatch-metric-stream/README.md
@@ -1,0 +1,111 @@
+# CLOUD AWS Cloudwatch Metric Stream SignalFx integrations
+
+## How to use this module
+
+```hcl
+variable "var.sfx_access_token" {
+  type = string
+}
+
+variable "var.sfx_ingest_url" {
+  type = string
+}
+
+module "signalfx-integrations-cloud-aws-cloudwatch-metric-stream" {
+  source = "github.com/claranet/terraform-signalfx-integrations.git//cloud/aws-cloudwatch-metric-stream?ref={revision}"
+
+  sfx_access_token = var.sfx_access_token
+  sfx_ingest_url = var.sfx_ingest_url
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.sfx_metric_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_stream.http_log_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_stream) | resource |
+| [aws_iam_policy.sfx_cloudwatch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.sfx_firehose_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.sfx_cloudwatch_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.sfx_firehose_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.sfx_cloudwatch_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.sfx_firehose_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kinesis_firehose_delivery_stream.sfx_metric_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
+| [aws_s3_bucket.sfx_metric_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.sfx_cloudwatch_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sfx_cloudwatch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sfx_firehose_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sfx_firehose_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | AWS CloudWatch log group retention in days | `number` | `14` | no |
+| <a name="input_sfx_access_token"></a> [sfx\_access\_token](#input\_sfx\_access\_token) | Access token used to push metrics to SignalFx | `string` | n/a | yes |
+| <a name="input_sfx_ingest_url"></a> [sfx\_ingest\_url](#input\_sfx\_ingest\_url) | Ingest URL used to push metrics to SignalFx | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->
+
+## Related documentation
+
+[Official documentation](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-wizardconfig.html#enable-cloudwatch-metric-streams)
+
+## Setup
+
+You need to configure your AWS provider:
+
+```
+variable "aws_access_key" {
+  type = string
+}
+
+variable "aws_secret_key" {
+  type = string
+}
+
+variable "aws_token" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  token      = var.aws_token
+  region     = var.aws_region
+}
+```
+
+## Notes
+
+- This module will create the AWS Cloudwatch Log Group, S3 bucket and Kinesis Data Firehose resources necessary for ingesting AWS Cloudwatch Metric Streams.
+- It must be deployed in each AWS region where you want to get metrics from.
+- It is usually used in conjonction with the main [aws](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws) module. When that's the case, you can pass the `signalfx_org_token` output from the `aws` module directly in the `sfx_access_token` of the `aws-cloudwatch-metric-stream` module.

--- a/cloud/aws-cloudwatch-metric-stream/README.md
+++ b/cloud/aws-cloudwatch-metric-stream/README.md
@@ -93,14 +93,37 @@ variable "aws_token" {
 }
 
 variable "aws_region" {
-  type = string
+  default = "eu-west-1"
+  type     = string
 }
-
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   token      = var.aws_token
   region     = var.aws_region
+}
+
+# Optional - example of configuration in multiple regions
+
+## we declare a new provider in a different region than the default (un-aliased) one
+provider "aws" {
+  alias = "us-west-1"
+
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  token      = var.aws_token
+  region     = "us-west-1"
+}
+
+## we import again this module but passing explicitly the provider for the other region
+module "signalfx-integrations-cloud-aws-cloudwatch-metric-stream-us-west-1" {
+  providers = {
+    aws = aws.us-west-1
+  }
+
+  source = "github.com/claranet/terraform-signalfx-integrations.git//cloud/aws-cloudwatch-metric-stream?ref={revision}"
+  sfx_access_token = var.sfx_access_token
+  sfx_ingest_url = var.sfx_ingest_url
 }
 ```
 

--- a/cloud/aws-cloudwatch-metric-stream/aws_cloudwatch_metric_stream.tf
+++ b/cloud/aws-cloudwatch-metric-stream/aws_cloudwatch_metric_stream.tf
@@ -1,0 +1,59 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "sfx_metric_stream" {
+  bucket = "splunk-metric-streams-s3-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+}
+
+resource "aws_cloudwatch_log_group" "sfx_metric_stream" {
+  name              = "/aws/kinesisfirehose/splunk-metric-streams-${data.aws_region.current.name}"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+}
+
+resource "aws_cloudwatch_log_stream" "http_log_stream" {
+  name           = "HttpEndpointDelivery"
+  log_group_name = aws_cloudwatch_log_group.sfx_metric_stream.name
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "sfx_metric_stream" {
+  name        = "splunk-metric-streams-${data.aws_region.current.name}"
+  destination = "http_endpoint"
+
+  s3_configuration {
+    role_arn           = aws_iam_role.sfx_firehose_role.arn
+    bucket_arn         = aws_s3_bucket.sfx_metric_stream.arn
+    buffer_size        = 1
+    buffer_interval    = 60
+    compression_format = "GZIP"
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.sfx_metric_stream.name
+      log_stream_name = aws_cloudwatch_log_stream.http_log_stream.name
+    }
+  }
+
+  http_endpoint_configuration {
+    url                = "${var.sfx_ingest_url}/v1/cloudwatch_metric_stream"
+    name               = "SignalFx"
+    access_key         = var.sfx_access_token
+    buffering_size     = 1
+    buffering_interval = 60
+    role_arn           = aws_iam_role.sfx_firehose_role.arn
+    s3_backup_mode     = "FailedDataOnly"
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.sfx_metric_stream.name
+      log_stream_name = aws_cloudwatch_log_stream.http_log_stream.name
+    }
+
+    request_configuration {
+      content_encoding = "GZIP"
+    }
+  }
+
+  tags = {
+    "splunk-metric-streams-firehose" = "${data.aws_region.current.name}"
+  }
+}

--- a/cloud/aws-cloudwatch-metric-stream/policies.tf
+++ b/cloud/aws-cloudwatch-metric-stream/policies.tf
@@ -1,0 +1,78 @@
+data "aws_iam_policy_document" "sfx_firehose_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sfx_firehose_policy" {
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      aws_s3_bucket.sfx_metric_stream.arn,
+      format("%s/*", aws_s3_bucket.sfx_metric_stream.arn),
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:PutLogEvents",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      format("%s:*", aws_cloudwatch_log_group.sfx_metric_stream.arn),
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sfx_firehose_policy" {
+  name   = "splunk-metric-streams-firehose-${data.aws_region.current.name}"
+  policy = data.aws_iam_policy_document.sfx_firehose_policy.json
+}
+
+data "aws_iam_policy_document" "sfx_cloudwatch_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["streams.metrics.cloudwatch.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sfx_cloudwatch_policy" {
+  statement {
+    actions = [
+      "firehose:PutRecord",
+      "firehose:PutRecordBatch"
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      aws_kinesis_firehose_delivery_stream.sfx_metric_stream.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sfx_cloudwatch_policy" {
+  name   = "splunk-metric-streams-cloudwatch-${data.aws_region.current.name}"
+  policy = data.aws_iam_policy_document.sfx_cloudwatch_policy.json
+}

--- a/cloud/aws-cloudwatch-metric-stream/roles.tf
+++ b/cloud/aws-cloudwatch-metric-stream/roles.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role" "sfx_firehose_role" {
+  name               = "splunk-metric-streams-s3-${data.aws_region.current.name}"
+  description        = "A role for Kinesis Firehose including the permissions to store failed requests in S3 and output logs"
+  assume_role_policy = data.aws_iam_policy_document.sfx_firehose_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "sfx_firehose_policy_attach" {
+  role       = aws_iam_role.sfx_firehose_role.name
+  policy_arn = aws_iam_policy.sfx_firehose_policy.arn
+}
+
+resource "aws_iam_role" "sfx_cloudwatch_role" {
+  name               = "splunk-metric-streams-${data.aws_region.current.name}"
+  description        = "A role that allows CloudWatch MetricStreams to publish to Kinesis Firehose"
+  assume_role_policy = data.aws_iam_policy_document.sfx_cloudwatch_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "sfx_cloudwatch_policy_attach" {
+  role       = aws_iam_role.sfx_cloudwatch_role.name
+  policy_arn = aws_iam_policy.sfx_cloudwatch_policy.arn
+}

--- a/cloud/aws-cloudwatch-metric-stream/variables.tf
+++ b/cloud/aws-cloudwatch-metric-stream/variables.tf
@@ -1,0 +1,15 @@
+variable "sfx_access_token" {
+  description = "Access token used to push metrics to SignalFx"
+  type        = string
+}
+
+variable "sfx_ingest_url" {
+  description = "Ingest URL used to push metrics to SignalFx"
+  type        = string
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "AWS CloudWatch log group retention in days"
+  type        = number
+  default     = 14
+}

--- a/cloud/aws-cloudwatch-metric-stream/versions.tf
+++ b/cloud/aws-cloudwatch-metric-stream/versions.tf
@@ -1,12 +1,8 @@
 terraform {
   required_providers {
-    signalfx = {
-      source  = "splunk-terraform/signalfx"
-      version = ">= 6.9.0"
-    }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2"
+      version = ">= 3.15.0"
     }
   }
   required_version = ">= 0.12.26"

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -16,14 +16,14 @@ module "signalfx-integrations-cloud-aws" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
-| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.7.10 |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 6.7.10 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 6.9.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
@@ -34,8 +34,10 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.sfx_metric_streams_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sfx_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.sfx_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.sfx_metric_streams_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.sfx_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [signalfx_aws_external_integration.aws_integration_external](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/aws_external_integration) | resource |
 | [signalfx_aws_integration.aws_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/aws_integration) | resource |
@@ -49,6 +51,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_regions"></a> [aws\_regions](#input\_aws\_regions) | List of AWS regions that SignalFx should monitor | `list(any)` | <pre>[<br>  "eu-west-1"<br>]</pre> | no |
+| <a name="input_create_metric_streams_iam"></a> [create\_metric\_streams\_iam](#input\_create\_metric\_streams\_iam) | Enable the creation of the IAM role required to enable Amazon's Cloudwatch Metric Streams for ingesting metrics. This is separate from the `use_metric_streams_sync` parameter as disabling Metric Streams still requires the existence of the IAM role | `bool` | `false` | no |
 | <a name="input_custom_namespace_sync_rule"></a> [custom\_namespace\_sync\_rule](#input\_custom\_namespace\_sync\_rule) | Each element controls the data collected by SignalFx for the specified namespace | <pre>object({<br>    default_action = string<br>    filter_action  = string<br>    filter_source  = string<br>    namespace      = string<br>  })</pre> | <pre>{<br>  "default_action": null,<br>  "filter_action": null,<br>  "filter_source": null,<br>  "namespace": "*"<br>}</pre> | no |
 | <a name="input_ec2_namespace_sync_rule"></a> [ec2\_namespace\_sync\_rule](#input\_ec2\_namespace\_sync\_rule) | Default namespace sync rule with filtering capabilities | <pre>object({<br>    default_action = string<br>    filter_action  = string<br>    filter_source  = string<br>    namespace      = string<br>  })</pre> | <pre>{<br>  "default_action": "Exclude",<br>  "filter_action": "Include",<br>  "filter_source": "filter('aws_tag_sfx_monitored', 'true')",<br>  "namespace": "AWS/EC2"<br>}</pre> | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the AWS integration is enabled | `bool` | `true` | no |
@@ -60,6 +63,7 @@ No modules.
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | AWS poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 | <a name="input_use_get_metric_data"></a> [use\_get\_metric\_data](#input\_use\_get\_metric\_data) | Enable the use of Amazon's GetMetricData for collecting metrics | `bool` | `true` | no |
+| <a name="input_use_metric_streams_sync"></a> [use\_metric\_streams\_sync](#input\_use\_metric\_streams\_sync) | Enable the use of Amazon's Cloudwatch Metric Streams for ingesting metrics. When setting it to `true`, you also need to set `create_metric_streams_iam` to `true` | `bool` | `false` | no |
 
 ## Outputs
 
@@ -69,6 +73,7 @@ No modules.
 | <a name="output_aws_role_arn"></a> [aws\_role\_arn](#output\_aws\_role\_arn) | The role ARN of the SignalFx integration |
 | <a name="output_aws_role_name"></a> [aws\_role\_name](#output\_aws\_role\_name) | The IAM role name of the SignalFx integration |
 | <a name="output_sfx_external_id"></a> [sfx\_external\_id](#output\_sfx\_external\_id) | SignalFx integration external ID |
+| <a name="output_signalfx_org_token"></a> [signalfx\_org\_token](#output\_signalfx\_org\_token) | Org token for ingesting data from AWS integration |
 <!-- END_TF_DOCS -->
 
 ## Related documentation
@@ -103,38 +108,48 @@ variable "aws_token" {
   type = string
 }
 
+variable "aws_region" {
+  type = string
+}
+
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   token      = var.aws_token
+  region     = var.aws_region
 }
 
 ```
 
 ## Notes
 
-* This module will create an organization token and use it for ingesting data from the created AWS integration.
+- This module will create an organization token and use it for ingesting data from the created AWS integration.
   This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
-* As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin
-* You need to be an IAM admin on AWS account
-* The apply will wait between the AWS policy attachment to role and the signalfx aws integration creation to prevent permission denied error
-* This module does not support `services` and `custom_cloudwatch_namespaces` because `namespace_sync_rule` and `custom_namespace_sync_rule` are respectively more powerful but in conflict
+- As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin
+- You need to be an IAM admin on AWS account
+- The apply will wait between the AWS policy attachment to role and the signalfx aws integration creation to prevent permission denied error
+- This module does not support `services` and `custom_cloudwatch_namespaces` because `namespace_sync_rule` and `custom_namespace_sync_rule` are respectively more powerful but in conflict
+- When enabling AWS Cloudwatch Metric Streams with `use_metric_streams_sync = true`, you also need to set `create_metric_streams_iam` to `true`. Then you need to create the Kinesis Data Firehose resources by yourself in each of the regions where you want to collect metrics from. You can use the [`aws-cloudwatch-metric-stream`](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws-cloudwatch-metric-stream) module to do this.
+- When disabling AWS Cloudwatch Metric Streams, make sure to apply in two phases:
+  - first change the `use_metric_streams_sync` parameter from `true` to `false` and run `terraform apply` to let it deprovision the AWS Cloudwatch Metric Streams resources it created,
+  - then change `create_metric_streams_iam` from `true` to `false` and run `terraform apply` to destroy the IAM role.
+    If you do not follow that process, the AWS integration will end up in `CANCELATION_FAILED` status.
 
 ### Namespaces filtering
 
 The filtering behavior of this module is voluntarily opinionated and could be compared to iptables rules:
 
-- a `namespace_sync_rule` will be added to include everything for all supported services 
-- __except__ for `AWS/EC2` namespace and all namespaces defined in the `excluded_services` list variable
-- a special `namespace_sync_rule` will be added for `AWS/EC2` to include metrics from instances where tags match the filter `aws_tag_sfx_monitored:true` as described in [this 
-documentation](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention#goal)
+- a `namespace_sync_rule` will be added to include everything for all supported services
+- **except** for `AWS/EC2` namespace and all namespaces defined in the `excluded_services` list variable
+- a special `namespace_sync_rule` will be added for `AWS/EC2` to include metrics from instances where tags match the filter `aws_tag_sfx_monitored:true` as described in [this
+  documentation](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention#goal)
 - and all metrics which do not match any of previous "including" rules will be "excluded" from collection
 
 It allows to avoid being billed for undesirable AWS EC2 instances but you can override this rule using `ec2_namespace_sync_rule` variable.
 
-Feel free to override `excluded_services` list to prevent collection of __any__ metrics from specific services (as 
+Feel free to override `excluded_services` list to prevent collection of **any** metrics from specific services (as
 [services](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/aws_integration#services) does natively).
 
-If there is any default value set for `excluded_services` this is probably because they are returned by the [data 
+If there is any default value set for `excluded_services` this is probably because they are returned by the [data
 source](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/data-sources/aws_services) but not yet supported for configuration of the integration.
 You can try to remove them and if you do not get error like `Not valid namespaces: [AWS/RoboMaker, AWS/MediaLive]` please open pull request to remove them from the default value.

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -37,6 +37,7 @@ resource "signalfx_aws_integration" "aws_integration" {
   import_cloud_watch         = var.import_cloudwatch
   enable_aws_usage           = var.import_aws_usage
   use_get_metric_data_method = var.use_get_metric_data
+  use_metric_streams_sync    = var.use_metric_streams_sync
 
   namespace_sync_rule {
     default_action = var.ec2_namespace_sync_rule.default_action
@@ -62,7 +63,8 @@ resource "signalfx_aws_integration" "aws_integration" {
 
   depends_on = [
     aws_iam_role_policy_attachment.sfx_policy_attach,
-    time_sleep.policy_availability
+    aws_iam_role_policy_attachment.sfx_metric_streams_policy_attach,
+    time_sleep.policy_availability,
   ]
 }
 

--- a/cloud/aws/outputs.tf
+++ b/cloud/aws/outputs.tf
@@ -18,3 +18,8 @@ output "sfx_external_id" {
   value       = signalfx_aws_integration.aws_integration.external_id
 }
 
+output "signalfx_org_token" {
+  description = "Org token for ingesting data from AWS integration"
+  value       = signalfx_org_token.aws_integration.secret
+  sensitive   = true
+}

--- a/cloud/aws/policies.tf
+++ b/cloud/aws/policies.tf
@@ -83,6 +83,32 @@ resource "aws_iam_policy" "sfx_policy" {
 EOF
 }
 
+resource "aws_iam_policy" "sfx_metric_streams_policy" {
+  count       = var.create_metric_streams_iam ? 1 : 0
+  name        = "SignalFxIntegrationMetricStreamsPolicy${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
+  description = "SignalFx AWS Policy for ingesting Cloudwatch Metric Streams"
+  policy      = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+    {
+        "Action": [
+            "cloudwatch:ListMetricStreams",
+            "cloudwatch:GetMetricStream",
+            "cloudwatch:PutMetricStream",
+            "cloudwatch:DeleteMetricStream",
+            "cloudwatch:StartMetricStreams",
+            "cloudwatch:StopMetricStreams",
+            "iam:PassRole"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
 data "aws_iam_policy_document" "sfx_policy_doc" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -9,10 +9,18 @@ resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {
   policy_arn = aws_iam_policy.sfx_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "sfx_metric_streams_policy_attach" {
+  count      = var.create_metric_streams_iam ? 1 : 0
+  role       = aws_iam_role.sfx_role.name
+  policy_arn = aws_iam_policy.sfx_metric_streams_policy[0].arn
+}
+
 # workaround to be sure the policy is really applied to the role before to try to create the integration
 resource "time_sleep" "policy_availability" {
-  depends_on = [aws_iam_role_policy_attachment.sfx_policy_attach]
+  depends_on = [
+    aws_iam_role_policy_attachment.sfx_policy_attach,
+    aws_iam_role_policy_attachment.sfx_metric_streams_policy_attach,
+  ]
 
   create_duration = "15s"
 }
-

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -56,6 +56,18 @@ variable "use_get_metric_data" {
   default     = true
 }
 
+variable "use_metric_streams_sync" {
+  description = "Enable the use of Amazon's Cloudwatch Metric Streams for ingesting metrics. When setting it to `true`, you also need to set `create_metric_streams_iam` to `true`"
+  type        = bool
+  default     = false
+}
+
+variable "create_metric_streams_iam" {
+  description = "Enable the creation of the IAM role required to enable Amazon's Cloudwatch Metric Streams for ingesting metrics. This is separate from the `use_metric_streams_sync` parameter as disabling Metric Streams still requires the existence of the IAM role"
+  type        = bool
+  default     = false
+}
+
 variable "excluded_services" {
   description = "List of AWS services to not collect metrics for (do not add an include namespace_sync_rule)"
   type        = list(any)


### PR DESCRIPTION
Depends on https://github.com/splunk-terraform/terraform-provider-signalfx/pull/344