### PR TITLE
Add ingest alerting integration

### DIFF
--- a/alerting/ingest-alerting/README.md
+++ b/alerting/ingest-alerting/README.md
@@ -1,0 +1,99 @@
+# ALERTING Ingest-Alerting SignalFx integrations
+
+## How to use this module
+
+```hcl
+module "signalfx-integrations-alerting-ingest-alerting" {
+  source  = "github.com/claranet/terraform-signalfx-integrations.git//alerting/ingest-alerting"
+
+  token   = var.ingest_alerting_token
+}
+```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 4.26.4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 4.26.4 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [signalfx_webhook_integration.sfx_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/webhook_integration) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_headers"></a> [additional\_headers](#input\_additional\_headers) | Any additional headers to send | `map(any)` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the Webhook integration is enabled | `bool` | `true` | no |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | Webhook name suffix, will precede the notif period | `string` | `"ingest-alerting"` | no |
+| <a name="input_token"></a> [token](#input\_token) | The ingest-alerting JWT token to authentificate | `string` | n/a | yes |
+| <a name="input_url"></a> [url](#input\_url) | The ingest-alerting URL to use | `string` | `"https://ingest-alerting.fr.clara.net/splunk"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_sfx_integration_id"></a> [sfx\_integration\_id](#output\_sfx\_integration\_id) | SignalFx integration ID |
+| <a name="output_sfx_integration_name"></a> [sfx\_integration\_name](#output\_sfx\_integration\_name) | SignalFx integration name |
+| <a name="output_sfx_integration_notification"></a> [sfx\_integration\_notification](#output\_sfx\_integration\_notification) | SignalFx integration formatted notification |
+<!-- END_TF_DOCS -->
+
+## Related documentation
+
+* [Official documentation](https://docs.signalfx.com/en/latest/admin-guide/integrate-notifications.html#send-notifications-via-a-webhook-url)
+
+## Setup
+
+You need to configure SignalFx provider and retrieve a ingest-alerting Auth.
+
+```
+variable "sfx_token" {
+  description = "User API token from an admin on SignalFx organization"
+  type        = string
+}
+
+provider "signalfx" {
+  auth_token = var.sfx_token                  # admin temporary session token
+  api_url    = "https://api.eu0.signalfx.com" # change for your realm
+}
+
+variable "ingest_alerting_token" {
+  description = "The ingest-alerting token to authentificate"
+  type        = string
+}
+```
+
+## Notes
+
+* As for any integration configuration you need a **session** token from your SignalFx user (and not an **org** access token)
+
+## Detector example
+
+```
+resource "signalfx_detector" "my_detector" {
+  // Detector stuff
+
+  rule {
+    description : "rule description"
+    severity      = "Severity"
+    detect_label  = "Detector Label ..."
+    notifications = [
+      module.signalfx-integrations-alerting-ingest-alerting.sfx_integration_notification
+    ]
+  }
+}
+```

--- a/alerting/ingest-alerting/README.md
+++ b/alerting/ingest-alerting/README.md
@@ -39,7 +39,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_headers"></a> [additional\_headers](#input\_additional\_headers) | Any additional headers to send | `map(any)` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the Webhook integration is enabled | `bool` | `true` | no |
-| <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix for the integration name | `string` | `""` | no |
 | <a name="input_token"></a> [token](#input\_token) | The ingest-alerting JWT token to authentificate | `string` | n/a | yes |
 | <a name="input_url"></a> [url](#input\_url) | The ingest-alerting URL to use | `string` | `"https://ingest-alerting.fr.clara.net/splunk"` | no |
 

--- a/alerting/ingest-alerting/README.md
+++ b/alerting/ingest-alerting/README.md
@@ -39,7 +39,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_headers"></a> [additional\_headers](#input\_additional\_headers) | Any additional headers to send | `map(any)` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the Webhook integration is enabled | `bool` | `true` | no |
-| <a name="input_suffix"></a> [suffix](#input\_suffix) | Webhook name suffix, will precede the notif period | `string` | `"ingest-alerting"` | no |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 | <a name="input_token"></a> [token](#input\_token) | The ingest-alerting JWT token to authentificate | `string` | n/a | yes |
 | <a name="input_url"></a> [url](#input\_url) | The ingest-alerting URL to use | `string` | `"https://ingest-alerting.fr.clara.net/splunk"` | no |
 

--- a/alerting/ingest-alerting/integrations-ingest-alerting.tf
+++ b/alerting/ingest-alerting/integrations-ingest-alerting.tf
@@ -1,5 +1,5 @@
 resource "signalfx_webhook_integration" "sfx_integration" {
-  name    = format("%s", var.suffix)
+  name    = local.integration_name
   enabled = var.enabled
   url     = var.url
   headers {

--- a/alerting/ingest-alerting/integrations-ingest-alerting.tf
+++ b/alerting/ingest-alerting/integrations-ingest-alerting.tf
@@ -1,0 +1,16 @@
+resource "signalfx_webhook_integration" "sfx_integration" {
+  name    = format("%s", var.suffix)
+  enabled = var.enabled
+  url     = var.url
+  headers {
+    header_key   = "Authorization"
+    header_value = "Bearer ${var.token}"
+  }
+  dynamic "headers" {
+    for_each = var.additional_headers
+    content {
+      header_key   = headers.key
+      header_value = headers.value
+    }
+  }
+}

--- a/alerting/ingest-alerting/locals.tf
+++ b/alerting/ingest-alerting/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  integration_name = "IngestAlerting${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
+}

--- a/alerting/ingest-alerting/outputs.tf
+++ b/alerting/ingest-alerting/outputs.tf
@@ -1,0 +1,14 @@
+output "sfx_integration_id" {
+  description = "SignalFx integration ID"
+  value       = signalfx_webhook_integration.sfx_integration.id
+}
+
+output "sfx_integration_name" {
+  description = "SignalFx integration name"
+  value       = signalfx_webhook_integration.sfx_integration.name
+}
+
+output "sfx_integration_notification" {
+  description = "SignalFx integration formatted notification"
+  value       = format("Webhook,%s,,", signalfx_webhook_integration.sfx_integration.id)
+}

--- a/alerting/ingest-alerting/variables.tf
+++ b/alerting/ingest-alerting/variables.tf
@@ -1,9 +1,9 @@
 # Global
 
 variable "suffix" {
-  description = "Webhook name suffix, will precede the notif period"
+  description = "Optional suffix to identify and avoid duplication of unique resources"
   type        = string
-  default     = "ingest-alerting"
+  default     = ""
 }
 
 # Ingest-Alerting Integration specific

--- a/alerting/ingest-alerting/variables.tf
+++ b/alerting/ingest-alerting/variables.tf
@@ -1,0 +1,32 @@
+# Global
+
+variable "suffix" {
+  description = "Webhook name suffix, will precede the notif period"
+  type        = string
+  default     = "ingest-alerting"
+}
+
+# Ingest-Alerting Integration specific
+
+variable "enabled" {
+  description = "Whether the Webhook integration is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "url" {
+  description = "The ingest-alerting URL to use"
+  type        = string
+  default     = "https://ingest-alerting.fr.clara.net/splunk"
+}
+
+variable "token" {
+  description = "The ingest-alerting JWT token to authentificate"
+  type        = string
+}
+
+variable "additional_headers" {
+  description = "Any additional headers to send"
+  type        = map(any)
+  default     = {}
+}

--- a/alerting/ingest-alerting/variables.tf
+++ b/alerting/ingest-alerting/variables.tf
@@ -1,7 +1,7 @@
 # Global
 
 variable "suffix" {
-  description = "Optional suffix to identify and avoid duplication of unique resources"
+  description = "Optional suffix for the integration name"
   type        = string
   default     = ""
 }

--- a/alerting/ingest-alerting/versions.tf
+++ b/alerting/ingest-alerting/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = ">= 4.26.4"
+    }
+  }
+  required_version = ">= 0.12.26"
+}


### PR DESCRIPTION
Add new alerting ingest integration. 

This has been tested with Code, project ID is not mandatory as the project can be retrieved through the token or can be sent via the `project-id` header.