### PR TITLE
support for `sync_guest_os_namespaces`, `custom_namespaces_per_service`, `additional_services` and `resource_filter_rules`

### DIFF
--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -66,14 +66,16 @@ module "signalfx-integrations-cloud-azure" {
 | <a name="input_additional_services"></a> [additional\_services](#input\_additional\_services) | Not yet officially supported Azure resource types to sync with SignalFx as custom metrics | `list(string)` | `null` | no |
 | <a name="input_azure_subscription_ids"></a> [azure\_subscription\_ids](#input\_azure\_subscription\_ids) | List of Azure Subscription IDs to monitor | `list(string)` | n/a | yes |
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | Azure Tenant ID/Directory ID | `string` | n/a | yes |
+| <a name="input_custom_namespaces_per_service"></a> [custom\_namespaces\_per\_service](#input\_custom\_namespaces\_per\_service) | List of maps for which each service key will be synced metrics from associated namespaces in addition to the default namespaces. It provides more fine-grained controle compared to the boolean convenience parameter "sync\_guest\_os\_namespaces" | <pre>list(object({<br>    service    = string<br>    namespaces = list(string)<br>  }))</pre> | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the Azure integration is enabled | `bool` | `true` | no |
 | <a name="input_excluded_services"></a> [excluded\_services](#input\_excluded\_services) | List of Azure services to not collect metrics for (removed from the `services` list) | `list(string)` | `[]` | no |
 | <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | Azure poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
-| <a name="input_resource_filter_rules"></a> [resource\_filter\_rules](#input\_resource\_filter\_rules) | List of rules for filtering Azure resources by their tags. Each filter follows "filter('key', 'value')". Referenced keys are limited to tags and must start with the "azure\_tag\_" prefix | `list(string)` | `null` | no |
+| <a name="input_resource_filter_rules"></a> [resource\_filter\_rules](#input\_resource\_filter\_rules) | List of rules for filtering Azure resources by their tags. Each filter follows "filter('key', 'value')". Referenced keys are limited to tags and must start with the "azure\_tag\_" prefix | <pre>list(object({<br>    filter = object({<br>      source = string<br>    })<br>  }))</pre> | `null` | no |
 | <a name="input_services"></a> [services](#input\_services) | Azure service metrics to import. Empty list imports all services | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
+| <a name="input_sync_guest_os_namespaces"></a> [sync\_guest\_os\_namespaces](#input\_sync\_guest\_os\_namespaces) | Sync additional namespaces for VMs (including VMs in scale sets) to pull metrics from Azure Diagnostics Extensision when enabled | `bool` | `false` | no |
 
 ## Outputs
 

--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -35,7 +35,7 @@ module "signalfx-integrations-cloud-azure" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 2 |
-| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.7.10 |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.11.0 |
 
 ## Providers
 

--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -71,6 +71,7 @@ module "signalfx-integrations-cloud-azure" {
 | <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | Azure poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
+| <a name="input_resource_filter_rules"></a> [resource\_filter\_rules](#input\_resource\_filter\_rules) | List of rules for filtering Azure resources by their tags. Each filter follows "filter('key', 'value')". Referenced keys are limited to tags and must start with the "azure\_tag\_" prefix | `list(string)` | `null` | no |
 | <a name="input_services"></a> [services](#input\_services) | Azure service metrics to import. Empty list imports all services | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 

--- a/cloud/azure/module-integration.tf
+++ b/cloud/azure/module-integration.tf
@@ -6,10 +6,11 @@ module "sfx_integration" {
   host_or_usage_limits = var.host_or_usage_limits
   notifications_limits = var.notifications_limits
 
-  services            = var.services
-  excluded_services   = var.excluded_services
-  additional_services = var.additional_services
-  suffix              = var.suffix
+  services              = var.services
+  excluded_services     = var.excluded_services
+  additional_services   = var.additional_services
+  resource_filter_rules = var.resource_filter_rules
+  suffix                = var.suffix
 
   azure_tenant_id            = var.azure_tenant_id
   azure_subscription_ids     = var.azure_subscription_ids

--- a/cloud/azure/module-integration.tf
+++ b/cloud/azure/module-integration.tf
@@ -3,14 +3,17 @@ module "sfx_integration" {
 
   enabled              = var.enabled
   poll_rate            = var.poll_rate
+  suffix               = var.suffix
   host_or_usage_limits = var.host_or_usage_limits
   notifications_limits = var.notifications_limits
 
-  services              = var.services
-  excluded_services     = var.excluded_services
-  additional_services   = var.additional_services
-  resource_filter_rules = var.resource_filter_rules
-  suffix                = var.suffix
+  services            = var.services
+  excluded_services   = var.excluded_services
+  additional_services = var.additional_services
+
+  resource_filter_rules         = var.resource_filter_rules
+  custom_namespaces_per_service = var.custom_namespaces_per_service
+  sync_guest_os_namespaces      = var.sync_guest_os_namespaces
 
   azure_tenant_id            = var.azure_tenant_id
   azure_subscription_ids     = var.azure_subscription_ids

--- a/cloud/azure/sfx/README.md
+++ b/cloud/azure/sfx/README.md
@@ -22,13 +22,13 @@ module "signalfx-integrations-cloud-azure" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.7.10 |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 6.7.10 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 6.11.0 |
 
 ## Modules
 

--- a/cloud/azure/sfx/README.md
+++ b/cloud/azure/sfx/README.md
@@ -51,14 +51,16 @@ No modules.
 | <a name="input_azure_sp_application_token"></a> [azure\_sp\_application\_token](#input\_azure\_sp\_application\_token) | Azure Service Principal application token (or password) | `string` | n/a | yes |
 | <a name="input_azure_subscription_ids"></a> [azure\_subscription\_ids](#input\_azure\_subscription\_ids) | List of Azure Subscription IDs to monitor | `list(string)` | n/a | yes |
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | Azure Tenant ID/Directory ID | `string` | n/a | yes |
+| <a name="input_custom_namespaces_per_service"></a> [custom\_namespaces\_per\_service](#input\_custom\_namespaces\_per\_service) | List of maps for which each service key will be synced metrics from associated namespaces in addition to the default namespaces. It provides more fine-grained controle compared to the boolean convenience parameter "sync\_guest\_os\_namespaces" | <pre>list(object({<br>    service    = string<br>    namespaces = list(string)<br>  }))</pre> | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the Azure integration is enabled | `bool` | `true` | no |
 | <a name="input_excluded_services"></a> [excluded\_services](#input\_excluded\_services) | List of Azure services to not collect metrics for (removed from the `services` list) | `list(string)` | `[]` | no |
 | <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | Azure poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
-| <a name="input_resource_filter_rules"></a> [resource\_filter\_rules](#input\_resource\_filter\_rules) | List of rules for filtering Azure resources by their tags. Each filter follows "filter('key', 'value')". Referenced keys are limited to tags and must start with the "azure\_tag\_" prefix | `list(string)` | `null` | no |
+| <a name="input_resource_filter_rules"></a> [resource\_filter\_rules](#input\_resource\_filter\_rules) | List of rules for filtering Azure resources by their tags. Each filter follows "filter('key', 'value')". Referenced keys are limited to tags and must start with the "azure\_tag\_" prefix | <pre>list(object({<br>    filter = object({<br>      source = string<br>    })<br>  }))</pre> | `null` | no |
 | <a name="input_services"></a> [services](#input\_services) | Azure service metrics to import. Empty list imports all services | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
+| <a name="input_sync_guest_os_namespaces"></a> [sync\_guest\_os\_namespaces](#input\_sync\_guest\_os\_namespaces) | Sync additional namespaces for VMs (including VMs in scale sets) to pull metrics from Azure Diagnostics Extensision when enabled | `bool` | `false` | no |
 
 ## Outputs
 

--- a/cloud/azure/sfx/README.md
+++ b/cloud/azure/sfx/README.md
@@ -56,6 +56,7 @@ No modules.
 | <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | Azure poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
+| <a name="input_resource_filter_rules"></a> [resource\_filter\_rules](#input\_resource\_filter\_rules) | List of rules for filtering Azure resources by their tags. Each filter follows "filter('key', 'value')". Referenced keys are limited to tags and must start with the "azure\_tag\_" prefix | `list(string)` | `null` | no |
 | <a name="input_services"></a> [services](#input\_services) | Azure service metrics to import. Empty list imports all services | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -12,8 +12,9 @@ resource "signalfx_azure_integration" "azure_integration" {
   app_id     = var.azure_sp_application_id
   secret_key = var.azure_sp_application_token
 
-  services           = setsubtract(local.azure_services, var.excluded_services)
-  additionalServices = var.additional_services
+  services              = setsubtract(local.azure_services, var.excluded_services)
+  additional_services   = var.additional_services
+  resource_filter_rules = var.resource_filter_rules
 
   tenant_id     = var.azure_tenant_id
   subscriptions = var.azure_subscription_ids

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -12,9 +12,26 @@ resource "signalfx_azure_integration" "azure_integration" {
   app_id     = var.azure_sp_application_id
   secret_key = var.azure_sp_application_token
 
-  services              = setsubtract(local.azure_services, var.excluded_services)
-  additional_services   = var.additional_services
-  resource_filter_rules = var.resource_filter_rules
+  services            = setsubtract(local.azure_services, var.excluded_services)
+  additional_services = var.additional_services
+
+  dynamic "resource_filter_rules" {
+    for_each = var.resource_filter_rules != null ? var.resource_filter_rules : []
+    content {
+      filter = {
+        source = lookup(resource_filter_rules.value.filter, "source", null)
+      }
+    }
+  }
+
+  sync_guest_os_namespaces = var.sync_guest_os_namespaces
+  dynamic "custom_namespaces_per_service" {
+    for_each = var.custom_namespaces_per_service != null ? var.custom_namespaces_per_service : []
+    content {
+      service    = custom_namespaces_per_service.value.service
+      namespaces = custom_namespaces_per_service.value.namespaces
+    }
+  }
 
   tenant_id     = var.azure_tenant_id
   subscriptions = var.azure_subscription_ids

--- a/cloud/azure/sfx/variables.tf
+++ b/cloud/azure/sfx/variables.tf
@@ -52,8 +52,27 @@ variable "additional_services" {
 
 variable "resource_filter_rules" {
   description = "List of rules for filtering Azure resources by their tags. Each filter follows \"filter('key', 'value')\". Referenced keys are limited to tags and must start with the \"azure_tag_\" prefix"
-  type        = list(string)
-  default     = null
+  type = list(object({
+    filter = object({
+      source = string
+    })
+  }))
+  default = null
+}
+
+variable "sync_guest_os_namespaces" {
+  description = "Sync additional namespaces for VMs (including VMs in scale sets) to pull metrics from Azure Diagnostics Extensision when enabled"
+  type        = bool
+  default     = false
+}
+
+variable "custom_namespaces_per_service" {
+  description = "List of maps for which each service key will be synced metrics from associated namespaces in addition to the default namespaces. It provides more fine-grained controle compared to the boolean convenience parameter \"sync_guest_os_namespaces\""
+  type = list(object({
+    service    = string
+    namespaces = list(string)
+  }))
+  default = null
 }
 
 variable "azure_tenant_id" {

--- a/cloud/azure/sfx/variables.tf
+++ b/cloud/azure/sfx/variables.tf
@@ -50,6 +50,12 @@ variable "additional_services" {
   default     = null
 }
 
+variable "resource_filter_rules" {
+  description = "List of rules for filtering Azure resources by their tags. Each filter follows \"filter('key', 'value')\". Referenced keys are limited to tags and must start with the \"azure_tag_\" prefix"
+  type        = list(string)
+  default     = null
+}
+
 variable "azure_tenant_id" {
   description = "Azure Tenant ID/Directory ID"
   type        = string

--- a/cloud/azure/sfx/versions.tf
+++ b/cloud/azure/sfx/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     signalfx = {
       source  = "splunk-terraform/signalfx"
-      version = ">= 6.7.10"
+      version = ">= 6.11.0"
     }
   }
   required_version = ">= 0.12.26"

--- a/cloud/azure/variables.tf
+++ b/cloud/azure/variables.tf
@@ -52,8 +52,27 @@ variable "additional_services" {
 
 variable "resource_filter_rules" {
   description = "List of rules for filtering Azure resources by their tags. Each filter follows \"filter('key', 'value')\". Referenced keys are limited to tags and must start with the \"azure_tag_\" prefix"
-  type        = list(string)
-  default     = null
+  type = list(object({
+    filter = object({
+      source = string
+    })
+  }))
+  default = null
+}
+
+variable "sync_guest_os_namespaces" {
+  description = "Sync additional namespaces for VMs (including VMs in scale sets) to pull metrics from Azure Diagnostics Extensision when enabled"
+  type        = bool
+  default     = false
+}
+
+variable "custom_namespaces_per_service" {
+  description = "List of maps for which each service key will be synced metrics from associated namespaces in addition to the default namespaces. It provides more fine-grained controle compared to the boolean convenience parameter \"sync_guest_os_namespaces\""
+  type = list(object({
+    service    = string
+    namespaces = list(string)
+  }))
+  default = null
 }
 
 # Azure Resources specific

--- a/cloud/azure/variables.tf
+++ b/cloud/azure/variables.tf
@@ -50,7 +50,13 @@ variable "additional_services" {
   default     = null
 }
 
-# Azure Resoources specific
+variable "resource_filter_rules" {
+  description = "List of rules for filtering Azure resources by their tags. Each filter follows \"filter('key', 'value')\". Referenced keys are limited to tags and must start with the \"azure_tag_\" prefix"
+  type        = list(string)
+  default     = null
+}
+
+# Azure Resources specific
 
 variable "azure_tenant_id" {
   description = "Azure Tenant ID/Directory ID"

--- a/cloud/azure/versions.tf
+++ b/cloud/azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     signalfx = {
       source  = "splunk-terraform/signalfx"
-      version = ">= 6.7.10"
+      version = ">= 6.11.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
`additional_services` was partially added previously by https://github.com/claranet/terraform-signalfx-integrations/pull/44 but does not work because of provider version and wrong attribute name