### PR TITLE
AWS - Allow to include services not only exclude

### DIFF
--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -65,8 +65,9 @@ No modules.
 | <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
 | <a name="input_import_aws_usage"></a> [import\_aws\_usage](#input\_import\_aws\_usage) | Import usage metrics from AWS to use with AWS Cost Optimizer | `bool` | `false` | no |
 | <a name="input_import_cloudwatch"></a> [import\_cloudwatch](#input\_import\_cloudwatch) | Import Cloud Watch metrics from AWS | `bool` | `true` | no |
-| <a name="input_included_services"></a> [included\_services](#input\_included\_services) | List of AWS services to collect metrics for (By default it will collect every AWS service supported by splunk) | `list(any)` | `[]` | no |
+| <a name="input_included_services"></a> [included\_services](#input\_included\_services) | List of AWS services to collect metrics for (By default it will collect every supported AWS services) | `list(any)` | `[]` | no |
 | <a name="input_metrics_stats_to_sync"></a> [metrics\_stats\_to\_sync](#input\_metrics\_stats\_to\_sync) | List of objects defining namespace, metric and stats to change the standard set of statistics retrieved by integration by specific ones. Useful to fetch statistics not available by default like percentile | <pre>list(object({<br>    namespace = string<br>    metric    = string<br>    stats     = list(string)<br>  }))</pre> | `null` | no |
+| <a name="input_namespace_sync_rules_filters"></a> [namespace\_sync\_rules\_filters](#input\_namespace\_sync\_rules\_filters) | Define a map of filters to apply on included services, each key is the namespace name and values are key values pairs defining default\_action, filter\_action and filter\_source. | `map(any)` | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | AWS poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
@@ -171,3 +172,23 @@ Feel free to override `excluded_services` list to prevent collection of **any** 
 If there is any default value set for `excluded_services` this is probably because they are returned by the [data
 source](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/data-sources/aws_services) but not yet supported for configuration of the integration.
 You can try to remove them and if you do not get error like `Not valid namespaces: [AWS/RoboMaker, AWS/MediaLive]` please open pull request to remove them from the default value.
+
+Instead of filtering out every service you do not want to get metrics from, you can only include the services you need. You can also filter the metric name to fetch for each namespace. This is useful to reduce the number of MTS and to reduce AWS CloudWatch cost.
+
+```
+included_services = [
+  "AWS/ELB",
+  "AWS/ApplicationELB",
+  "AWS/RDS",
+  "AWS/ElastiCache",
+  "AWS/ES"
+]
+
+namespace_sync_rules_filters = {
+  "AWS/ELB" = {
+    default_action = "Exclude"
+    filter_action  = "Include"
+    filter_source = "filter('sf_metric','Latency','HTTPCode_ELB_5XX','RequestCount','HTTPCode_ELB_4XX','HTTPCode_Backend_5XX','HTTPCode_Backend_4XX','HealthyHostCount','UnHealthyHostCount')"
+  }
+}
+```

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -65,6 +65,7 @@ No modules.
 | <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
 | <a name="input_import_aws_usage"></a> [import\_aws\_usage](#input\_import\_aws\_usage) | Import usage metrics from AWS to use with AWS Cost Optimizer | `bool` | `false` | no |
 | <a name="input_import_cloudwatch"></a> [import\_cloudwatch](#input\_import\_cloudwatch) | Import Cloud Watch metrics from AWS | `bool` | `true` | no |
+| <a name="input_included_services"></a> [included\_services](#input\_included\_services) | List of AWS services to collect metrics for (By default it will collect every AWS service supported by splunk) | `list(any)` | `[]` | no |
 | <a name="input_metrics_stats_to_sync"></a> [metrics\_stats\_to\_sync](#input\_metrics\_stats\_to\_sync) | List of objects defining namespace, metric and stats to change the standard set of statistics retrieved by integration by specific ones. Useful to fetch statistics not available by default like percentile | <pre>list(object({<br>    namespace = string<br>    metric    = string<br>    stats     = list(string)<br>  }))</pre> | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | AWS poll rate in seconds (One of 60 or 300) | `number` | `300` | no |

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -173,7 +173,7 @@ If there is any default value set for `excluded_services` this is probably becau
 source](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/data-sources/aws_services) but not yet supported for configuration of the integration.
 You can try to remove them and if you do not get error like `Not valid namespaces: [AWS/RoboMaker, AWS/MediaLive]` please open pull request to remove them from the default value.
 
-Instead of filtering out every service you do not want to get metrics from, you can only include the services you need. You can also filter the metric name to fetch for each namespace. This is useful to reduce the number of MTS and to reduce AWS CloudWatch cost.
+Instead of filtering out every service you do not want to get metrics from, you can only include the services you need. You can also filter the metrics to fetch for each namespace. This is useful to reduce the number of MTS and to reduce AWS CloudWatch costs.
 
 ```
 included_services = [

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -51,9 +51,12 @@ resource "signalfx_aws_integration" "aws_integration" {
 
   dynamic "namespace_sync_rule" {
     iterator = iter
-    for_each = local.open_aws_services
+    for_each = setsubtract(local.aws_services, local.excluded_services)
     content {
-      namespace = iter.value
+      default_action = try(lookup(var.namespace_sync_rules_filters[iter.value], "default_action", null), null)
+      filter_action  = try(lookup(var.namespace_sync_rules_filters[iter.value], "filter_action", null), null)
+      filter_source  = try(lookup(var.namespace_sync_rules_filters[iter.value], "filter_source", null), null)
+      namespace      = iter.value
     }
   }
 

--- a/cloud/aws/locals.tf
+++ b/cloud/aws/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  integration_name = "AWSIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
-  all_services = data.signalfx_aws_services.aws_services.services[*].name
+  integration_name  = "AWSIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
+  all_services      = data.signalfx_aws_services.aws_services.services[*].name
   excluded_services = concat(var.excluded_services, ["AWS/EC2"])
-  aws_services = coalescelist(tolist(setintersection(var.included_services, local.all_services)), local.all_services)
+  aws_services      = coalescelist(tolist(setintersection(var.included_services, local.all_services)), local.all_services)
 }

--- a/cloud/aws/locals.tf
+++ b/cloud/aws/locals.tf
@@ -1,8 +1,7 @@
 locals {
   integration_name = "AWSIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
-  open_aws_services = [
+  open_aws_services = coalescelist(var.included_services, [
     for service in data.signalfx_aws_services.aws_services.services[*].name :
     service if !contains(concat(["AWS/EC2"], var.excluded_services), service)
-  ]
+  ])
 }
-

--- a/cloud/aws/locals.tf
+++ b/cloud/aws/locals.tf
@@ -1,7 +1,6 @@
 locals {
   integration_name = "AWSIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
-  open_aws_services = coalescelist(var.included_services, [
-    for service in data.signalfx_aws_services.aws_services.services[*].name :
-    service if !contains(concat(["AWS/EC2"], var.excluded_services), service)
-  ])
+  all_services = data.signalfx_aws_services.aws_services.services[*].name
+  excluded_services = concat(var.excluded_services, ["AWS/EC2"])
+  aws_services = coalescelist(tolist(setintersection(var.included_services, local.all_services)), local.all_services)
 }

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -86,6 +86,12 @@ variable "create_metric_streams_iam" {
   default     = false
 }
 
+variable "included_services" {
+  description = "List of AWS services to collect metrics for (By default it will collect every AWS service supported by splunk)"
+  type        = list(any)
+  default     = []
+}
+
 variable "excluded_services" {
   description = "List of AWS services to not collect metrics for (do not add an include namespace_sync_rule)"
   type        = list(any)

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -87,9 +87,15 @@ variable "create_metric_streams_iam" {
 }
 
 variable "included_services" {
-  description = "List of AWS services to collect metrics for (By default it will collect every AWS service supported by splunk)"
+  description = "List of AWS services to collect metrics for (By default it will collect every supported AWS services)"
   type        = list(any)
   default     = []
+}
+
+variable "namespace_sync_rules_filters" {
+  description = "Define a map of filters to apply on included services, each key is the namespace name and values are key values pairs defining default_action, filter_action and filter_source."
+  type        = map(any)
+  default     = null
 }
 
 variable "excluded_services" {


### PR DESCRIPTION
I find it easier to be able to include only some specific services instead of only excluding. We have some orgs where we want to enable only a few services and it would be easier to do it that way.