### PR TITLE
fix version because whitelist is unsupported after v6.20

### DIFF
--- a/cloud/gcp/versions.tf
+++ b/cloud/gcp/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     signalfx = {
       source  = "splunk-terraform/signalfx"
-      version = ">= 6.7.10"
+      version = ">= 6.7.10, < 6.21.0"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Argument `whitelist` is unsupported after signalfx provider v6.20.
Therefore, here's a fixed provider version to fix tag v0.11.0

ref: 
* https://github.com/claranet/terraform-signalfx-integrations/blob/c682a43942baaf4b8d443ee1708b8a478dd3f6f1/cloud/gcp/integrations-gcp.tf#L31
* https://registry.terraform.io/providers/splunk-terraform/signalfx/6.21.0/docs/resources/gcp_integration
