### PR TITLE
Disconnection sfx token creation

### DIFF
--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -77,6 +77,7 @@ module "signalfx-integrations-cloud-azure" {
 | <a name="input_services"></a> [services](#input\_services) | Azure service metrics to import. Empty list imports all services | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 | <a name="input_sync_guest_os_namespaces"></a> [sync\_guest\_os\_namespaces](#input\_sync\_guest\_os\_namespaces) | Sync additional namespaces for VMs (including VMs in scale sets) to pull metrics from Azure Diagnostics Extensision when enabled | `bool` | `false` | no |
+| <a name="input_signalfx_token_name"></a> [signalfx_token_name](#input\_signalfx_token_name) | Optional signalfx token name. To use a sfx token already existing | `string` | `""` | no |
 
 ## Outputs
 

--- a/cloud/azure/module-integration.tf
+++ b/cloud/azure/module-integration.tf
@@ -19,4 +19,6 @@ module "sfx_integration" {
   azure_subscription_ids     = var.azure_subscription_ids
   azure_sp_application_id    = azuread_application.signalfx_integration.application_id
   azure_sp_application_token = azuread_service_principal_password.signalfx_integration_sp_pwd.value
+
+  signalfx_token_name        = var.signalfx_token_name
 }

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -38,6 +38,7 @@ resource "signalfx_azure_integration" "azure_integration" {
 }
 
 # "Named token to use for ingest on the SignalFx Azure integration"
+# We need a specific token to avoid using the Default organization one.
 resource "signalfx_org_token" "azure_integration" {
   count       = var.signalfx_token_name != null ? 0 : 1
   name        = local.integration_name

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -40,7 +40,7 @@ resource "signalfx_azure_integration" "azure_integration" {
 # "Named token to use for ingest on the SignalFx Azure integration"
 # We need a specific token to avoid using the Default organization one.
 resource "signalfx_org_token" "azure_integration" {
-  count       = var.signalfx_token_name != null ? 0 : 1
+  count       = var.signalfx_token_name != null && var.signalfx_token_name != "" ? 0 : 1
   name        = local.integration_name
   description = "Org token for ingesting data from ${local.integration_name} Azure integration"
 

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -4,7 +4,7 @@ data "signalfx_azure_services" "azure_services" {
 resource "signalfx_azure_integration" "azure_integration" {
   name        = local.integration_name
   enabled     = var.enabled
-  named_token = var.signalfx_token_name != null ? var.signalfx_token_name : signalfx_org_token.azure_integration[0].name
+  named_token = var.signalfx_token_name != null ? var.signalfx_token_name : one(signalfx_org_token.azure_integration[*].name)
   environment = "azure"
 
   poll_rate = var.poll_rate

--- a/cloud/azure/sfx/integrations-azure.tf
+++ b/cloud/azure/sfx/integrations-azure.tf
@@ -4,7 +4,7 @@ data "signalfx_azure_services" "azure_services" {
 resource "signalfx_azure_integration" "azure_integration" {
   name        = local.integration_name
   enabled     = var.enabled
-  named_token = signalfx_org_token.azure_integration.name
+  named_token = var.signalfx_token_name != null ? var.signalfx_token_name : signalfx_org_token.azure_integration[0].name
   environment = "azure"
 
   poll_rate = var.poll_rate
@@ -39,6 +39,7 @@ resource "signalfx_azure_integration" "azure_integration" {
 
 # "Named token to use for ingest on the SignalFx Azure integration"
 resource "signalfx_org_token" "azure_integration" {
+  count       = var.signalfx_token_name != null ? 0 : 1
   name        = local.integration_name
   description = "Org token for ingesting data from ${local.integration_name} Azure integration"
 

--- a/cloud/azure/sfx/variables.tf
+++ b/cloud/azure/sfx/variables.tf
@@ -94,3 +94,9 @@ variable "azure_sp_application_token" {
   description = "Azure Service Principal application token (or password)"
   type        = string
 }
+
+variable "signalfx_token_name" {
+  description = "Name of sfx token to use"
+  type        = string
+  default     = null
+}

--- a/cloud/azure/sfx/variables.tf
+++ b/cloud/azure/sfx/variables.tf
@@ -96,7 +96,7 @@ variable "azure_sp_application_token" {
 }
 
 variable "signalfx_token_name" {
-  description = "Name of sfx token to use"
+  description = "Name of already existing SFX token to use"
   type        = string
   default     = null
 }

--- a/cloud/azure/variables.tf
+++ b/cloud/azure/variables.tf
@@ -92,3 +92,9 @@ variable "azure_spn_token_validity_duration" {
   type        = string
   default     = "${24 * 365 * 2}h" # 2 years
 }
+
+variable "signalfx_token_name" {
+  description = "Name of sfx token to use"
+  type        = string
+  default     = null
+}

--- a/cloud/azure/variables.tf
+++ b/cloud/azure/variables.tf
@@ -94,7 +94,7 @@ variable "azure_spn_token_validity_duration" {
 }
 
 variable "signalfx_token_name" {
-  description = "Name of sfx token to use"
+  description = "Name of already existing SFX token to use"
   type        = string
   default     = null
 }


### PR DESCRIPTION
The purpose of this PR is to add the possibility to not create a token when creating the signalfx integration, and to use an already existing token with the "signalfx_token_name" variable. 