### PR TITLE
BUGFIX: aws: data.signalfx_aws_services is now deprecated, replace it

### DIFF
--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -14,17 +14,17 @@ module "signalfx-integrations-cloud-aws" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
-| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.9.0 |
+| terraform | >= 0.12.26 |
+| aws | >= 2 |
+| signalfx | >= 6.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 6.9.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| aws | >= 2 |
+| signalfx | >= 6.9.0 |
+| time | n/a |
 
 ## Modules
 
@@ -47,42 +47,40 @@ No modules.
 | [time_sleep.logs_policy_availability](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.policy_availability](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.sfx_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [signalfx_aws_services.aws_services](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/data-sources/aws_services) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_regions"></a> [aws\_regions](#input\_aws\_regions) | List of AWS regions that SignalFx should monitor | `list(any)` | <pre>[<br>  "eu-west-1"<br>]</pre> | no |
-| <a name="input_create_logs_iam"></a> [create\_logs\_iam](#input\_create\_logs\_iam) | Enable the creation of the IAM role required to enable Amazon's Cloudwatch Logs sync. This is separate from the `enable_logs_sync` parameter as disabling Logs still requires the existence of the IAM role | `bool` | `false` | no |
-| <a name="input_create_metric_streams_iam"></a> [create\_metric\_streams\_iam](#input\_create\_metric\_streams\_iam) | Enable the creation of the IAM role required to enable Amazon's Cloudwatch Metric Streams for ingesting metrics. This is separate from the `use_metric_streams_sync` parameter as disabling Metric Streams still requires the existence of the IAM role | `bool` | `false` | no |
-| <a name="input_custom_namespace_sync_rules"></a> [custom\_namespace\_sync\_rules](#input\_custom\_namespace\_sync\_rules) | List where each element is a rule which controls the data collected by SignalFx for the specified namespace | <pre>list(object({<br>    default_action = string<br>    filter_action  = string<br>    filter_source  = string<br>    namespace      = string<br>  }))</pre> | `null` | no |
-| <a name="input_ec2_namespace_sync_rule"></a> [ec2\_namespace\_sync\_rule](#input\_ec2\_namespace\_sync\_rule) | Default namespace sync rule with filtering capabilities | <pre>object({<br>    default_action = string<br>    filter_action  = string<br>    filter_source  = string<br>    namespace      = string<br>  })</pre> | <pre>{<br>  "default_action": "Exclude",<br>  "filter_action": "Include",<br>  "filter_source": "filter('aws_tag_sfx_monitored', 'true')",<br>  "namespace": "AWS/EC2"<br>}</pre> | no |
-| <a name="input_enable_check_large_volume"></a> [enable\_check\_large\_volume](#input\_enable\_check\_large\_volume) | Enable monitoring of the amount of data coming in from the integration | `bool` | `false` | no |
-| <a name="input_enable_logs_sync"></a> [enable\_logs\_sync](#input\_enable\_logs\_sync) | Enable the AWS logs synchronization. When setting it to `true`, you also need to set `create_logs_iam` to `true` | `bool` | `false` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the AWS integration is enabled | `bool` | `true` | no |
-| <a name="input_excluded_services"></a> [excluded\_services](#input\_excluded\_services) | List of AWS services to not collect metrics for (do not add an include namespace\_sync\_rule) | `list(any)` | `[]` | no |
-| <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
-| <a name="input_import_aws_usage"></a> [import\_aws\_usage](#input\_import\_aws\_usage) | Import usage metrics from AWS to use with AWS Cost Optimizer | `bool` | `false` | no |
-| <a name="input_import_cloudwatch"></a> [import\_cloudwatch](#input\_import\_cloudwatch) | Import Cloud Watch metrics from AWS | `bool` | `true` | no |
-| <a name="input_included_services"></a> [included\_services](#input\_included\_services) | List of AWS services to collect metrics for (By default it will collect every supported AWS services) | `list(any)` | `[]` | no |
-| <a name="input_metrics_stats_to_sync"></a> [metrics\_stats\_to\_sync](#input\_metrics\_stats\_to\_sync) | List of objects defining namespace, metric and stats to change the standard set of statistics retrieved by integration by specific ones. Useful to fetch statistics not available by default like percentile | <pre>list(object({<br>    namespace = string<br>    metric    = string<br>    stats     = list(string)<br>  }))</pre> | `null` | no |
-| <a name="input_namespace_sync_rules_filters"></a> [namespace\_sync\_rules\_filters](#input\_namespace\_sync\_rules\_filters) | Define a map of filters to apply on included services, each key is the namespace name and values are key values pairs defining default\_action, filter\_action and filter\_source. | `map(any)` | `null` | no |
-| <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
-| <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | AWS poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
-| <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
-| <a name="input_use_get_metric_data"></a> [use\_get\_metric\_data](#input\_use\_get\_metric\_data) | Enable the use of Amazon's GetMetricData for collecting metrics | `bool` | `true` | no |
-| <a name="input_use_metric_streams_sync"></a> [use\_metric\_streams\_sync](#input\_use\_metric\_streams\_sync) | Enable the use of Amazon's Cloudwatch Metric Streams for ingesting metrics. When setting it to `true`, you also need to set `create_metric_streams_iam` to `true` | `bool` | `false` | no |
+| aws\_regions | List of AWS regions that SignalFx should monitor | `list(any)` | <pre>[<br>  "eu-west-1"<br>]</pre> | no |
+| create\_logs\_iam | Enable the creation of the IAM role required to enable Amazon's Cloudwatch Logs sync. This is separate from the `enable_logs_sync` parameter as disabling Logs still requires the existence of the IAM role | `bool` | `false` | no |
+| create\_metric\_streams\_iam | Enable the creation of the IAM role required to enable Amazon's Cloudwatch Metric Streams for ingesting metrics. This is separate from the `use_metric_streams_sync` parameter as disabling Metric Streams still requires the existence of the IAM role | `bool` | `false` | no |
+| custom\_namespace\_sync\_rules | List where each element is a rule which controls the data collected by SignalFx for the specified namespace | <pre>list(object({<br>    default_action = string<br>    filter_action  = string<br>    filter_source  = string<br>    namespace      = string<br>  }))</pre> | `null` | no |
+| ec2\_namespace\_sync\_rule | Default namespace sync rule with filtering capabilities | <pre>object({<br>    default_action = string<br>    filter_action  = string<br>    filter_source  = string<br>    namespace      = string<br>  })</pre> | <pre>{<br>  "default_action": "Exclude",<br>  "filter_action": "Include",<br>  "filter_source": "filter('aws_tag_sfx_monitored', 'true')",<br>  "namespace": "AWS/EC2"<br>}</pre> | no |
+| enable\_check\_large\_volume | Enable monitoring of the amount of data coming in from the integration | `bool` | `false` | no |
+| enable\_logs\_sync | Enable the AWS logs synchronization. When setting it to `true`, you also need to set `create_logs_iam` to `true` | `bool` | `false` | no |
+| enabled | Whether the AWS integration is enabled | `bool` | `true` | no |
+| excluded\_services | List of AWS services to not collect metrics for (do not add an include namespace\_sync\_rule) | `list(any)` | `[]` | no |
+| host\_or\_usage\_limits | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
+| import\_aws\_usage | Import usage metrics from AWS to use with AWS Cost Optimizer | `bool` | `false` | no |
+| import\_cloudwatch | Import Cloud Watch metrics from AWS | `bool` | `true` | no |
+| included\_services | List of AWS services to collect metrics for (By default it will collect every supported AWS services) | `list(any)` | `[]` | no |
+| metrics\_stats\_to\_sync | List of objects defining namespace, metric and stats to change the standard set of statistics retrieved by integration by specific ones. Useful to fetch statistics not available by default like percentile | <pre>list(object({<br>    namespace = string<br>    metric    = string<br>    stats     = list(string)<br>  }))</pre> | `null` | no |
+| namespace\_sync\_rules\_filters | Define a map of filters to apply on included services, each key is the namespace name and values are key values pairs defining default\_action, filter\_action and filter\_source. | `map(any)` | `null` | no |
+| notifications\_limits | Where to send notifications about this token's limits | `list(string)` | `null` | no |
+| poll\_rate | AWS poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
+| suffix | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
+| use\_metric\_streams\_sync | Enable the use of Amazon's Cloudwatch Metric Streams for ingesting metrics. When setting it to `true`, you also need to set `create_metric_streams_iam` to `true` | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_integration_id"></a> [aws\_integration\_id](#output\_aws\_integration\_id) | SignalFx integration ID |
-| <a name="output_aws_role_arn"></a> [aws\_role\_arn](#output\_aws\_role\_arn) | The role ARN of the SignalFx integration |
-| <a name="output_aws_role_name"></a> [aws\_role\_name](#output\_aws\_role\_name) | The IAM role name of the SignalFx integration |
-| <a name="output_sfx_external_id"></a> [sfx\_external\_id](#output\_sfx\_external\_id) | SignalFx integration external ID |
-| <a name="output_signalfx_org_token"></a> [signalfx\_org\_token](#output\_signalfx\_org\_token) | Org token for ingesting data from AWS integration |
+| aws\_integration\_id | SignalFx integration ID |
+| aws\_role\_arn | The role ARN of the SignalFx integration |
+| aws\_role\_name | The IAM role name of the SignalFx integration |
+| sfx\_external\_id | SignalFx integration external ID |
+| signalfx\_org\_token | Org token for ingesting data from AWS integration |
 <!-- END_TF_DOCS -->
 
 ## Related documentation

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -26,16 +26,16 @@ resource "signalfx_aws_integration" "aws_integration" {
   enabled     = var.enabled
   named_token = signalfx_org_token.aws_integration.name
 
-  integration_id             = signalfx_aws_external_integration.aws_integration_external.id
-  external_id                = signalfx_aws_external_integration.aws_integration_external.external_id
-  role_arn                   = aws_iam_role.sfx_role.arn
-  regions                    = var.aws_regions
-  poll_rate                  = var.poll_rate
-  import_cloud_watch         = var.import_cloudwatch
-  enable_aws_usage           = var.import_aws_usage
-  enable_check_large_volume  = var.enable_check_large_volume
-  enable_logs_sync           = var.enable_logs_sync
-  use_metric_streams_sync    = var.use_metric_streams_sync
+  integration_id            = signalfx_aws_external_integration.aws_integration_external.id
+  external_id               = signalfx_aws_external_integration.aws_integration_external.external_id
+  role_arn                  = aws_iam_role.sfx_role.arn
+  regions                   = var.aws_regions
+  poll_rate                 = var.poll_rate
+  import_cloud_watch        = var.import_cloudwatch
+  enable_aws_usage          = var.import_aws_usage
+  enable_check_large_volume = var.enable_check_large_volume
+  enable_logs_sync          = var.enable_logs_sync
+  use_metric_streams_sync   = var.use_metric_streams_sync
 
 
   namespace_sync_rule {

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -35,7 +35,6 @@ resource "signalfx_aws_integration" "aws_integration" {
   enable_aws_usage           = var.import_aws_usage
   enable_check_large_volume  = var.enable_check_large_volume
   enable_logs_sync           = var.enable_logs_sync
-  use_get_metric_data_method = var.use_get_metric_data
   use_metric_streams_sync    = var.use_metric_streams_sync
 
 

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -18,9 +18,6 @@ resource "signalfx_org_token" "aws_integration" {
   }
 }
 
-data "signalfx_aws_services" "aws_services" {
-}
-
 resource "signalfx_aws_external_integration" "aws_integration_external" {
   name = local.integration_name
 }

--- a/cloud/aws/locals.tf
+++ b/cloud/aws/locals.tf
@@ -1,6 +1,5 @@
 locals {
   integration_name  = "AWSIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
-  all_services      = data.signalfx_aws_services.aws_services.services[*].name
   excluded_services = concat(var.excluded_services, ["AWS/EC2"])
-  aws_services      = coalescelist(tolist(setintersection(var.included_services, local.all_services)), local.all_services)
+  aws_services      = var.included_services
 }

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -68,12 +68,6 @@ variable "create_logs_iam" {
   default     = false
 }
 
-variable "use_get_metric_data" {
-  description = "Enable the use of Amazon's GetMetricData for collecting metrics"
-  type        = bool
-  default     = true
-}
-
 variable "use_metric_streams_sync" {
   description = "Enable the use of Amazon's Cloudwatch Metric Streams for ingesting metrics. When setting it to `true`, you also need to set `create_metric_streams_iam` to `true`"
   type        = bool


### PR DESCRIPTION
https://github.com/splunk-terraform/terraform-provider-signalfx/blob/main/CHANGELOG.md#800

> Remove data resources signalfx_aws_services, signalfx_azure_services, signalfx_gcp_services as they were based on a no longer maintained lists in the signalfx-go library. Users may use empty list to specify "all services" instead or use strings to specify selected services.