### PR TITLE
AWS disconnection sfx token creation

### DIFF
--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -23,9 +23,9 @@ module "signalfx-integrations-cloud-aws" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 8.1.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | >= 0.9.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 8.1.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
 
 ## Modules
 

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -71,6 +71,7 @@ No modules.
 | <a name="input_namespace_sync_rules_filters"></a> [namespace\_sync\_rules\_filters](#input\_namespace\_sync\_rules\_filters) | Define a map of filters to apply on included services, each key is the namespace name and values are key values pairs defining default\_action, filter\_action and filter\_source. | `map(any)` | `null` | no |
 | <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
 | <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | AWS poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
+| <a name="input_signalfx_token_name"></a> [signalfx\_token\_name](#input\_signalfx\_token\_name) | Name of already existing SFX token to use | `string` | `null` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
 | <a name="input_use_metric_streams_sync"></a> [use\_metric\_streams\_sync](#input\_use\_metric\_streams\_sync) | Enable the use of Amazon's Cloudwatch Metric Streams for ingesting metrics. When setting it to `true`, you also need to set `create_metric_streams_iam` to `true` | `bool` | `false` | no |
 

--- a/cloud/aws/integrations-aws.tf
+++ b/cloud/aws/integrations-aws.tf
@@ -1,4 +1,7 @@
+# "Named token to use for ingest on the SignalFx AWS integration"
+# We need a specific token to avoid using the Default organization one.
 resource "signalfx_org_token" "aws_integration" {
+  count       = var.signalfx_token_name != null && var.signalfx_token_name != "" ? 0 : 1
   name        = local.integration_name
   description = "Org token for ingesting data from ${local.integration_name} AWS integration"
 
@@ -24,7 +27,7 @@ resource "signalfx_aws_external_integration" "aws_integration_external" {
 
 resource "signalfx_aws_integration" "aws_integration" {
   enabled     = var.enabled
-  named_token = signalfx_org_token.aws_integration.name
+  named_token = var.signalfx_token_name != null ? var.signalfx_token_name : one(signalfx_org_token.aws_integration[*].name)
 
   integration_id            = signalfx_aws_external_integration.aws_integration_external.id
   external_id               = signalfx_aws_external_integration.aws_integration_external.external_id

--- a/cloud/aws/outputs.tf
+++ b/cloud/aws/outputs.tf
@@ -20,6 +20,6 @@ output "sfx_external_id" {
 
 output "signalfx_org_token" {
   description = "Org token for ingesting data from AWS integration"
-  value       = signalfx_org_token.aws_integration.secret
+  value       = try(signalfx_org_token.aws_integration[0].secret, "")
   sensitive   = true
 }

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -232,3 +232,8 @@ variable "metrics_stats_to_sync" {
   default = null
 }
 
+variable "signalfx_token_name" {
+  description = "Name of already existing SFX token to use"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
The purpose of this PR is to add the possibility to not create a token when creating the signalfx integration, and to use an already existing token with the "signalfx_token_name" variable.