### PR TITLE
Allow boundary on role

### DIFF
--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "sfx_role" {
   name                 = "SignalFxIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
   description          = "SignalFx integration to read out data and send it to SignalFx's AWS account"
   assume_role_policy   = data.aws_iam_policy_document.sfx_policy_doc.json
-  permissions_boundary = try(var.sfx_role_permissions_boundary, false) ? var.sfx_role_permissions_boundary : null
+  permissions_boundary = var.sfx_role_permissions_boundary == null ? var.sfx_role_permissions_boundary : null
 }
 
 resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {

--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "sfx_role" {
   name                 = "SignalFxIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
   description          = "SignalFx integration to read out data and send it to SignalFx's AWS account"
   assume_role_policy   = data.aws_iam_policy_document.sfx_policy_doc.json
-  permissions_boundary = var.sfx_role_permissions_boundary != null ? var.sfx_role_permissions_boundary : null
+  permissions_boundary = var.sfx_role_permissions_boundary
 }
 
 resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {

--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -2,6 +2,7 @@ resource "aws_iam_role" "sfx_role" {
   name               = "SignalFxIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
   description        = "SignalFx integration to read out data and send it to SignalFx's AWS account"
   assume_role_policy = data.aws_iam_policy_document.sfx_policy_doc.json
+  permissions_boundary = var.sfx_role_permissions_boundary ? var.sfx_role_permissions_boundary : null
 }
 
 resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {

--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "sfx_role" {
   name                 = "SignalFxIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
   description          = "SignalFx integration to read out data and send it to SignalFx's AWS account"
   assume_role_policy   = data.aws_iam_policy_document.sfx_policy_doc.json
-  permissions_boundary = var.sfx_role_permissions_boundary == null ? var.sfx_role_permissions_boundary : null
+  permissions_boundary = var.sfx_role_permissions_boundary != null ? var.sfx_role_permissions_boundary : null
 }
 
 resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {

--- a/cloud/aws/roles.tf
+++ b/cloud/aws/roles.tf
@@ -1,8 +1,8 @@
 resource "aws_iam_role" "sfx_role" {
-  name               = "SignalFxIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
-  description        = "SignalFx integration to read out data and send it to SignalFx's AWS account"
-  assume_role_policy = data.aws_iam_policy_document.sfx_policy_doc.json
-  permissions_boundary = var.sfx_role_permissions_boundary ? var.sfx_role_permissions_boundary : null
+  name                 = "SignalFxIntegration${var.suffix == "" ? "" : "-${title(var.suffix)}"}"
+  description          = "SignalFx integration to read out data and send it to SignalFx's AWS account"
+  assume_role_policy   = data.aws_iam_policy_document.sfx_policy_doc.json
+  permissions_boundary = try(var.sfx_role_permissions_boundary, false) ? var.sfx_role_permissions_boundary : null
 }
 
 resource "aws_iam_role_policy_attachment" "sfx_policy_attach" {

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -237,3 +237,9 @@ variable "signalfx_token_name" {
   type        = string
   default     = null
 }
+
+variable "sfx_role_permissions_boundary" {
+  description = "ARN of the permissions boundary to be attached to the role, if needed"
+  type = string
+  default = null
+}

--- a/cloud/aws/variables.tf
+++ b/cloud/aws/variables.tf
@@ -240,6 +240,6 @@ variable "signalfx_token_name" {
 
 variable "sfx_role_permissions_boundary" {
   description = "ARN of the permissions boundary to be attached to the role, if needed"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
On a client's account, we are not IAM Admins, so we need to attach a boundary policy to the role created by the module, in order to limit what we can do.

This PR is there to permit this feature, and should not change anything when there is no boundary policy used.