### PR TITLE
Mark `sfx_external_id` output as sensitive

### DIFF
--- a/cloud/aws/outputs.tf
+++ b/cloud/aws/outputs.tf
@@ -16,6 +16,7 @@ output "aws_integration_id" {
 output "sfx_external_id" {
   description = "SignalFx integration external ID"
   value       = signalfx_aws_integration.aws_integration.external_id
+  sensitive   = true
 }
 
 output "signalfx_org_token" {


### PR DESCRIPTION
Pour corriger cette erreur avec Terrraform 1.5.6 : 

│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 16:
│   16: output "sfx_external_id" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
