### PR TITLE
fix(cloud/gcp)!: Remove reference to `signalfx_gcp_services` which is deprecated since v8.0.0 of signalfx provider

### DIFF
--- a/cloud/gcp/README.md
+++ b/cloud/gcp/README.md
@@ -12,20 +12,21 @@ module "signalfx-integrations-cloud-gcp" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3 |
-| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | >= 6.21.0 |
+| Name                                                                     | Version    |
+| ------------------------------------------------------------------------ | ---------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.12.26 |
+| <a name="requirement_google"></a> [google](#requirement_google)          | >= 3       |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement_signalfx)    | >= 6.21.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | >= 6.21.0 |
+| Name                                                            | Version   |
+| --------------------------------------------------------------- | --------- |
+| <a name="provider_google"></a> [google](#provider_google)       | >= 3      |
+| <a name="provider_signalfx"></a> [signalfx](#provider_signalfx) | >= 6.21.0 |
 
 ## Modules
 
@@ -33,36 +34,36 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_project_iam_custom_role.sfx_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| Name                                                                                                                                                          | Type     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| [google_project_iam_custom_role.sfx_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role)             | resource |
 | [google_project_iam_member.sfx_service_account_membership](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_service_account.sfx_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_key.sak](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
-| [signalfx_gcp_integration.gcp_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/gcp_integration) | resource |
-| [signalfx_org_token.gcp_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/org_token) | resource |
-| [signalfx_gcp_services.gcp_services](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/data-sources/gcp_services) | data source |
+| [google_service_account.sfx_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account)                  | resource |
+| [google_service_account_key.sak](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key)                          | resource |
+| [signalfx_gcp_integration.gcp_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/gcp_integration)           | resource |
+| [signalfx_org_token.gcp_integration](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/org_token)                       | resource |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the GCP integration is enabled | `bool` | `true` | no |
-| <a name="input_gcp_compute_metadata_whitelist"></a> [gcp\_compute\_metadata\_whitelist](#input\_gcp\_compute\_metadata\_whitelist) | List of GCP compute metadata to whitelist for use with the SignalFx GCP integration | `list(string)` | <pre>[<br>  "sfx_env",<br>  "sfx_monitored"<br>]</pre> | no |
-| <a name="input_gcp_project_id"></a> [gcp\_project\_id](#input\_gcp\_project\_id) | GCP project id for use with the SignalFx GCP integration | `string` | n/a | yes |
-| <a name="input_gcp_service_account_id"></a> [gcp\_service\_account\_id](#input\_gcp\_service\_account\_id) | GCP service account id for use with the SignalFx GCP integration | `string` | `""` | no |
-| <a name="input_host_or_usage_limits"></a> [host\_or\_usage\_limits](#input\_host\_or\_usage\_limits) | Specify Usage-based limits for this integration | `map(number)` | `null` | no |
-| <a name="input_notifications_limits"></a> [notifications\_limits](#input\_notifications\_limits) | Where to send notifications about this token's limits | `list(string)` | `null` | no |
-| <a name="input_poll_rate"></a> [poll\_rate](#input\_poll\_rate) | GCP poll rate in seconds (One of 60 or 300) | `number` | `300` | no |
-| <a name="input_services"></a> [services](#input\_services) | GCP service metrics to import. Empty list imports all services | `list(any)` | `[]` | no |
-| <a name="input_suffix"></a> [suffix](#input\_suffix) | Optional suffix to identify and avoid duplication of unique resources | `string` | `""` | no |
+| Name                                                                                                                        | Description                                                                                                                                                                                                 | Type           | Default                                              | Required |
+| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------- | :------: |
+| <a name="input_enabled"></a> [enabled](#input_enabled)                                                                      | Whether the GCP integration is enabled                                                                                                                                                                      | `bool`         | `true`                                               |    no    |
+| <a name="input_gcp_compute_metadata_whitelist"></a> [gcp_compute_metadata_whitelist](#input_gcp_compute_metadata_whitelist) | List of GCP compute metadata to whitelist for use with the SignalFx GCP integration                                                                                                                         | `list(string)` | <pre>[<br> "sfx_env",<br> "sfx_monitored"<br>]</pre> |    no    |
+| <a name="input_gcp_project_id"></a> [gcp_project_id](#input_gcp_project_id)                                                 | GCP project id for use with the SignalFx GCP integration                                                                                                                                                    | `string`       | n/a                                                  |   yes    |
+| <a name="input_gcp_service_account_id"></a> [gcp_service_account_id](#input_gcp_service_account_id)                         | GCP service account id for use with the SignalFx GCP integration                                                                                                                                            | `string`       | `""`                                                 |    no    |
+| <a name="input_host_or_usage_limits"></a> [host_or_usage_limits](#input_host_or_usage_limits)                               | Specify Usage-based limits for this integration                                                                                                                                                             | `map(number)`  | `null`                                               |    no    |
+| <a name="input_notifications_limits"></a> [notifications_limits](#input_notifications_limits)                               | Where to send notifications about this token's limits                                                                                                                                                       | `list(string)` | `null`                                               |    no    |
+| <a name="input_poll_rate"></a> [poll_rate](#input_poll_rate)                                                                | GCP poll rate in seconds (One of 60 or 300)                                                                                                                                                                 | `number`       | `300`                                                |    no    |
+| <a name="input_services"></a> [services](#input_services)                                                                   | GCP service metrics to import. Empty list imports all services. Find all available services [here](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html#google-cloud-platform-services). | `list(any)`    | `[]`                                                 |    no    |
+| <a name="input_suffix"></a> [suffix](#input_suffix)                                                                         | Optional suffix to identify and avoid duplication of unique resources                                                                                                                                       | `string`       | `""`                                                 |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_gcp_service_account_id"></a> [gcp\_service\_account\_id](#output\_gcp\_service\_account\_id) | The GCP service account id used by SignalFx |
-| <a name="output_signalfx_named_token"></a> [signalfx\_named\_token](#output\_signalfx\_named\_token) | The SignalFx named token used by the GCP integration |
+| Name                                                                                                  | Description                                          |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| <a name="output_gcp_service_account_id"></a> [gcp_service_account_id](#output_gcp_service_account_id) | The GCP service account id used by SignalFx          |
+| <a name="output_signalfx_named_token"></a> [signalfx_named_token](#output_signalfx_named_token)       | The SignalFx named token used by the GCP integration |
+
 <!-- END_TF_DOCS -->
 
 ## Related documentation
@@ -73,14 +74,15 @@ No modules.
 
 **WARNING:** When the `gcp_service_account_id` parameter is not provided, this module creates a service account and uses the `google_project_iam_member` resource which is not compatible with IAM permissions set externally and authoritatively managed with the `google_project_iam_policy` resource. If you happen to use the `google_project_iam_policy` resource on the provided GCP project,
 make sure to provide the `gcp_service_account_id` parameter and ensure the corresponding service account has the appropriate IAM permissions on the GCP project:
- - monitoring.metricDescriptors.get
- - monitoring.metricDescriptors.list
- - monitoring.timeSeries.list
- - resourcemanager.projects.get
- - compute.instances.list
- - compute.machineTypes.list
- - spanner.instances.list
- - storage.buckets.list
+
+- monitoring.metricDescriptors.get
+- monitoring.metricDescriptors.list
+- monitoring.timeSeries.list
+- resourcemanager.projects.get
+- compute.instances.list
+- compute.machineTypes.list
+- spanner.instances.list
+- storage.buckets.list
 
 You need to configure your GCP and SignalFx providers.
 Credentials could be set in your `terraform.tfvars`.
@@ -108,7 +110,7 @@ provider "google" {
 
 ## Notes
 
-* This module will create an organization token and use it for ingesting data from the created GCP integration.
+- This module will create an organization token and use it for ingesting data from the created GCP integration.
   This allows to distinguish hosts/metrics counts across monitored environments (e.g. staging, preprod, prod) and set specific limits.
-* As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin
-* You need to be an IAM admin on GCP account
+- As for any integration configuration you need a [**session**](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#user-api-access-tokens) token from an admin
+- You need to be an IAM admin on GCP account

--- a/cloud/gcp/integrations-gcp.tf
+++ b/cloud/gcp/integrations-gcp.tf
@@ -19,15 +19,12 @@ resource "signalfx_org_token" "gcp_integration" {
   }
 }
 
-data "signalfx_gcp_services" "gcp_services" {
-}
-
 resource "signalfx_gcp_integration" "gcp_integration" {
   name        = local.integration_name
   enabled     = var.enabled
   named_token = signalfx_org_token.gcp_integration.name
   poll_rate   = var.poll_rate
-  services    = coalescelist(var.services, data.signalfx_gcp_services.gcp_services.services[*].name)
+  services    = var.services
 
   include_list = var.gcp_compute_metadata_whitelist
 


### PR DESCRIPTION
https://github.com/splunk-terraform/terraform-provider-signalfx/blob/main/CHANGELOG.md#800 

> Remove data resources signalfx_aws_services, signalfx_azure_services, signalfx_gcp_services as they were based on a no longer maintained lists in the signalfx-go library. Users may use empty list to specify "all services" instead or use strings to specify selected services. 

We were only using it for gcp.